### PR TITLE
Restore preset selection handler compatibility

### DIFF
--- a/core/image_stream_bridge.py
+++ b/core/image_stream_bridge.py
@@ -28,7 +28,7 @@ CMD_IMG_NUM_RESPONSE = 0x11
 CMD_FILE_IMG_TRANSFER= 0x12
 
 
-__all__ = ["ImageStreamBridge"]
+__all__ = ["ImageStreamBridge", "ImageBridgeCore"]
 
 
 class ImageStreamBridge:
@@ -531,7 +531,7 @@ class ImageStreamBridge:
             pass
 
 
-class ImageStreamBridge(ImageBridgeCore):
+class ImageBridgeCore(ImageStreamBridge):
 
     """Concrete alias retained for backwards compatibility."""
 

--- a/ui/gimbal_window.py
+++ b/ui/gimbal_window.py
@@ -620,6 +620,13 @@ class GimbalControlsWindow(tk.Toplevel):
             self.v_yaw.set(yw)
 
     def on_select_preset(self, idx: int) -> None:
+        """Handle user selection of a preset radio button."""
+
+        self._apply_preset(idx)
+
+    def _apply_preset(self, idx: int) -> None:
+        """Compatibility shim for legacy preset selection callbacks."""
+
         idx = max(0, min(MAX_SENSOR_PRESETS - 1, idx))
         self._load_selected_preset(idx, apply_runtime=True)
 
@@ -658,32 +665,6 @@ class GimbalControlsWindow(tk.Toplevel):
         self.v_preset_name.set(self._default_preset_name(idx))
         self._update_preset_labels()
         self._write_back_state()
-        messagebox.showinfo("Cleared", f"Preset {idx + 1} cleared.")
-
-    def on_select_preset(self, idx: int) -> None:
-        self.v_preset_index.set(idx)
-        self._apply_preset(idx)
-        self._sync_gimbal_config_metadata()
-
-    def on_save_preset(self) -> None:
-        idx = int(self.v_preset_index.get())
-        try:
-            values = self._collect_values()
-        except Exception as e:
-            messagebox.showerror("Error", f"Save preset failed:\n{e}")
-            return
-        name = self.v_preset_name.get().strip() or self._default_preset_name(idx)
-        self.presets[idx] = {"name": name, "values": values}
-        self.v_preset_name.set(name)
-        self._sync_preset_widgets()
-        self._sync_gimbal_config_metadata()
-        messagebox.showinfo("Saved", f"Preset {idx + 1} saved.")
-
-    def on_clear_preset(self) -> None:
-        idx = int(self.v_preset_index.get())
-        self.presets[idx] = None
-        self._sync_preset_widgets()
-        self._sync_gimbal_config_metadata()
         messagebox.showinfo("Cleared", f"Preset {idx + 1} cleared.")
 
     def on_apply_pose(self) -> None:


### PR DESCRIPTION
## Summary
- ensure preset radio selections continue to trigger runtime updates via on_select_preset
- add an _apply_preset compatibility shim that forwards to the modern loader logic

## Testing
- python -m compileall core ui

------
https://chatgpt.com/codex/tasks/task_e_68d8a7529fe0832594fd7ad9cbf00043