### PR TITLE
Forward Set_Gimbal commands to gimbal controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ pyinstaller --noconfirm --clean --name MroUnifiedBridge \
 | Cmd ID | 이름 | Payload 구조 | 비고 |
 | ------ | ---- | ------------ | ---- |
 | `0x01` | Req_Capture | `<uint8 capture=1>` | 최신 이미지(UDP 수신본)를 SaveFile 디렉터리에 저장하고 파일 번호를 +1. |
-| `0x02` | Set_Gimbal | `<float x, y, z, roll, pitch, yaw>` | 예약 기능(현재 미사용). |
+| `0x02` | Set_Gimbal | `<float x, y, z, roll, pitch, yaw>` | 이미지 스트림 설정에 지정된 센서 유형/ID로 짐벌 제어 모듈에 전달되어 UDP SensorGimbalCtrl 패킷을 즉시 발사합니다. |
 | `0x03` | Set_Count | `<uint32 count_num>` | 다음 저장될 이미지 번호를 설정(000~999 순환). |
 | `0x04` | Get_ImgNum | `<uint8 get_flag=1>` | 마지막으로 저장된 이미지 번호 질의. `Img_Num_Response`(0x11) 반환. |
 | `0x05` | Req_SendImg | `<uint32 img_num>` | 지정 번호 이미지를 TCP 전송. `File_ImgTransfer`(0x12) 응답. |

--- a/core/gimbal_control.py
+++ b/core/gimbal_control.py
@@ -7,7 +7,7 @@ import socket
 import struct
 import threading
 import time
-from typing import Callable, Optional, Dict, Any, List, Tuple, Set
+from typing import Callable, Optional, Dict, Any, List, Set, Tuple
 
 from pymavlink import mavutil
 try:
@@ -16,39 +16,18 @@ except ImportError:
     from serial.serialutil import SerialException
 
 from utils.helpers import euler_to_quat
-
-TYPE_GIMBAL_CTRL = 10706
-TYPE_POWER_CTRL  = 10707
-
-# 임무컴퓨터 Heartbeat 기대값
-MC_HB_TYPE = 18
-
-GIMBAL_STATUS_FLAGS = 2  # 요구사항
-
-PARAM_TABLE: List[Tuple[str, float, int]] = [
-    ("VERSION_X", 7, 9), ("SRL_NUMBER", 100, 9), ("STIFF_TILT", 50, 9),
-    ("RC_CHAN_STILT", 2, 9), ("STIFF_ROLL", 50, 9), ("STIFF_PAN", 50, 9),
-    ("FILTER_OUT", 1, 9), ("RC_CHAN_SPAN", 2, 9), ("PWR_TILT", 30, 9),
-    ("PWR_ROLL", 30, 9), ("PWR_PAN", 30, 9), ("FLW_SP_TILT", 50, 9),
-    ("GMB_HOME_PAN", 900, 9), ("FLW_SP_PAN", 80, 9), ("FLW_LPF_TILT", 50, 9),
-    ("MAPPING_ANGLE", 0, 9), ("FLW_LPF_PAN", 50, 9), ("GYRO_TRUST", 100, 9),
-    ("RC_DZONE_TILT", 40, 9), ("RC_DZONE_ROLL", 40, 9), ("RC_DZONE_PAN", 40, 9),
-    ("RC_TYPE", 15, 9), ("GYRO_LPF", 5, 9), ("RC_LIM_MIN_TILT", -90, 9),
-    ("RC_LIM_MAX_TILT", 90, 9), ("RC_LIM_MIN_ROLL", -20, 9),
-    ("RC_LIM_MAX_ROLL", 20, 9), ("RC_LPF_TILT", 20, 9), ("RC_LPF_ROLL", 20, 9),
-    ("RC_LPF_PAN", 20, 9), ("RC_CHAN_TILT", 1, 9), ("RC_CHAN_ROLL", 7, 9),
-    ("RC_CHAN_PAN", 0, 9), ("RC_CHAN_MODE", 6, 9), ("RC_TRIM_TILT", 0, 9),
-    ("RC_TRIM_ROLL", 0, 9), ("RC_TRIM_PAN", 0, 9), ("RC_MODE_TILT", 1, 9),
-    ("RC_MODE_ROLL", 0, 9), ("RC_MODE_PAN", 1, 9), ("FLW_WD_TILT", 10, 9),
-    ("FLW_WD_PAN", 10, 9), ("RC_SPD_TILT", 50, 9), ("RC_SPD_ROLL", 50, 9),
-    ("RC_SPD_PAN", 50, 9), ("RC_REVERSE_AXIS", 0, 9), ("VERSION_Y", 8, 9),
-    ("VERSION_Z", 3, 9), ("RC_LIM_MIN_PAN", -45, 9), ("RC_LIM_MAX_PAN", 45, 9),
-    ("MAV_EMIT_HB", 1, 9), ("MAV_RATE_ST", 1, 9), ("MAV_RATE_ENCCNT", 10, 9),
-    ("MAV_TS_ENCNT", 1, 9), ("MAV_RATE_ORIEN", 10, 9), ("MAV_RATE_IMU", 15, 9),
-    ("BAUDRATE_COM2", 1152, 9), ("BAUDRATE_COM4", 0, 9), ("GIMBAL_COMPID", 154, 9),
-    ("TILT_DAMPING", 20, 9), ("ROLL_DAMPING", 15, 9), ("PAN_DAMPING", 20, 9),
-]
-PARAM_COUNT = len(PARAM_TABLE)
+from network.gimbal_icd import (
+    TYPE_GIMBAL_CTRL,
+    TYPE_POWER_CTRL,
+    MC_HB_TYPE,
+    GIMBAL_STATUS_FLAGS,
+    TCP_CMD_SET_TARGET,
+    TCP_CMD_SET_ZOOM,
+    TCP_CMD_GET_STATUS,
+    TCP_CMD_STATUS,
+    PARAM_TABLE,
+    PARAM_COUNT,
+)
 
 
 def _quat_to_euler_deg(qx: float, qy: float, qz: float, qw: float):
@@ -63,14 +42,6 @@ def _quat_to_euler_deg(qx: float, qy: float, qz: float, qw: float):
     cosy_cosp = 1.0 - 2.0 * (y*y + z*z)
     yaw = math.degrees(math.atan2(siny_cosp, cosy_cosp))
     return roll, pitch, yaw
-
-
-TCP_CMD_SET_TARGET = 0x01
-TCP_CMD_SET_ZOOM = 0x02
-TCP_CMD_GET_STATUS = 0x80
-TCP_CMD_STATUS = 0x81
-
-
 class GimbalControl:
     def __init__(
         self,
@@ -251,6 +222,49 @@ class GimbalControl:
             )
         except Exception as exc:
             self.log(f"[GIMBAL] preset UDP send error: {exc}")
+
+    def get_generator_endpoint(self) -> Tuple[str, int]:
+        with self._lock:
+            ip = str(self.s.get("generator_ip", "127.0.0.1"))
+            port = int(self.s.get("generator_port", 15020))
+        return ip, port
+
+    def apply_external_pose(
+        self,
+        sensor_type: int,
+        sensor_id: int,
+        pos_x: float,
+        pos_y: float,
+        pos_z: float,
+        roll_deg: float,
+        pitch_deg: float,
+        yaw_deg: float,
+    ) -> None:
+        """Handle an external Set_Gimbal request originating from the image stream module."""
+
+        sensor_type_i = int(sensor_type)
+        sensor_id_i = int(sensor_id)
+        with self._lock:
+            self.sensor_type = sensor_type_i
+            self.sensor_id = sensor_id_i
+            self.s["sensor_type"] = sensor_type_i
+            self.s["sensor_id"] = sensor_id_i
+
+        self.set_target_pose(pos_x, pos_y, pos_z, roll_deg, pitch_deg, yaw_deg)
+        self.send_udp_preset(
+            sensor_type_i,
+            sensor_id_i,
+            pos_x,
+            pos_y,
+            pos_z,
+            roll_deg,
+            pitch_deg,
+            yaw_deg,
+        )
+        self.log(
+            "[GIMBAL] external pose applied -> sensor=%d/%d xyz=(%.2f,%.2f,%.2f) rpy=(%.2f,%.2f,%.2f)"
+            % (sensor_type_i, sensor_id_i, pos_x, pos_y, pos_z, roll_deg, pitch_deg, yaw_deg)
+        )
 
     def set_mav_ids(self, sys_id: int, comp_id: int) -> None:
         with self._lock:

--- a/network/__init__.py
+++ b/network/__init__.py
@@ -1,0 +1,9 @@
+"""Network ICD definitions for Unified Bridge modules."""
+
+from . import image_stream_icd, gimbal_icd, gazebo_relay_icd
+
+__all__ = [
+    "image_stream_icd",
+    "gimbal_icd",
+    "gazebo_relay_icd",
+]

--- a/network/gazebo_relay_icd.py
+++ b/network/gazebo_relay_icd.py
@@ -1,0 +1,26 @@
+"""ICD constants for the Gazebo relay module."""
+
+from __future__ import annotations
+
+import struct
+
+GAZEBO_STRUCT_FMT = "<BiIBIQdddfffffff"
+GAZEBO_STRUCT_SIZE = struct.calcsize(GAZEBO_STRUCT_FMT)
+
+DIST_MSG_TYPE = 10708
+DIST_HDR_FMT = "<BiIB"
+DIST_HDR_SIZE = struct.calcsize(DIST_HDR_FMT)
+DIST_PAYLOAD_FMT = "<I H H H B B B B f f f f f f B"
+DIST_PAYLOAD_SIZE = struct.calcsize(DIST_PAYLOAD_FMT)
+DIST_TOTAL_MIN = DIST_HDR_SIZE + DIST_PAYLOAD_SIZE
+
+__all__ = [
+    "GAZEBO_STRUCT_FMT",
+    "GAZEBO_STRUCT_SIZE",
+    "DIST_MSG_TYPE",
+    "DIST_HDR_FMT",
+    "DIST_HDR_SIZE",
+    "DIST_PAYLOAD_FMT",
+    "DIST_PAYLOAD_SIZE",
+    "DIST_TOTAL_MIN",
+]

--- a/network/gimbal_icd.py
+++ b/network/gimbal_icd.py
@@ -1,0 +1,55 @@
+"""ICD constants for the Gimbal control module."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+TYPE_GIMBAL_CTRL = 10706
+TYPE_POWER_CTRL = 10707
+
+MC_HB_TYPE = 18
+GIMBAL_STATUS_FLAGS = 2
+
+TCP_CMD_SET_TARGET = 0x01
+TCP_CMD_SET_ZOOM = 0x02
+TCP_CMD_GET_STATUS = 0x80
+TCP_CMD_STATUS = 0x81
+
+PARAM_TABLE: List[Tuple[str, float, int]] = [
+    ("VERSION_X", 7, 9), ("SRL_NUMBER", 100, 9), ("STIFF_TILT", 50, 9),
+    ("RC_CHAN_STILT", 2, 9), ("STIFF_ROLL", 50, 9), ("STIFF_PAN", 50, 9),
+    ("FILTER_OUT", 1, 9), ("RC_CHAN_SPAN", 2, 9), ("PWR_TILT", 30, 9),
+    ("PWR_ROLL", 30, 9), ("PWR_PAN", 30, 9), ("FLW_SP_TILT", 50, 9),
+    ("GMB_HOME_PAN", 900, 9), ("FLW_SP_PAN", 80, 9), ("FLW_LPF_TILT", 50, 9),
+    ("MAPPING_ANGLE", 0, 9), ("FLW_LPF_PAN", 50, 9), ("GYRO_TRUST", 100, 9),
+    ("RC_DZONE_TILT", 40, 9), ("RC_DZONE_ROLL", 40, 9), ("RC_DZONE_PAN", 40, 9),
+    ("RC_TYPE", 15, 9), ("GYRO_LPF", 5, 9), ("RC_LIM_MIN_TILT", -90, 9),
+    ("RC_LIM_MAX_TILT", 90, 9), ("RC_LIM_MIN_ROLL", -20, 9),
+    ("RC_LIM_MAX_ROLL", 20, 9), ("RC_LPF_TILT", 20, 9), ("RC_LPF_ROLL", 20, 9),
+    ("RC_LPF_PAN", 20, 9), ("RC_CHAN_TILT", 1, 9), ("RC_CHAN_ROLL", 7, 9),
+    ("RC_CHAN_PAN", 0, 9), ("RC_CHAN_MODE", 6, 9), ("RC_TRIM_TILT", 0, 9),
+    ("RC_TRIM_ROLL", 0, 9), ("RC_TRIM_PAN", 0, 9), ("RC_MODE_TILT", 1, 9),
+    ("RC_MODE_ROLL", 0, 9), ("RC_MODE_PAN", 1, 9), ("FLW_WD_TILT", 10, 9),
+    ("FLW_WD_PAN", 10, 9), ("RC_SPD_TILT", 50, 9), ("RC_SPD_ROLL", 50, 9),
+    ("RC_SPD_PAN", 50, 9), ("RC_REVERSE_AXIS", 0, 9), ("VERSION_Y", 8, 9),
+    ("VERSION_Z", 3, 9), ("RC_LIM_MIN_PAN", -45, 9), ("RC_LIM_MAX_PAN", 45, 9),
+    ("MAV_EMIT_HB", 1, 9), ("MAV_RATE_ST", 1, 9), ("MAV_RATE_ENCCNT", 10, 9),
+    ("MAV_TS_ENCNT", 1, 9), ("MAV_RATE_ORIEN", 10, 9), ("MAV_RATE_IMU", 15, 9),
+    ("BAUDRATE_COM2", 1152, 9), ("BAUDRATE_COM4", 0, 9), ("GIMBAL_COMPID", 154, 9),
+    ("TILT_DAMPING", 20, 9), ("ROLL_DAMPING", 15, 9), ("PAN_DAMPING", 20, 9),
+]
+
+PARAM_COUNT = len(PARAM_TABLE)
+
+__all__ = [
+    "TYPE_GIMBAL_CTRL",
+    "TYPE_POWER_CTRL",
+    "MC_HB_TYPE",
+    "GIMBAL_STATUS_FLAGS",
+    "TCP_CMD_SET_TARGET",
+    "TCP_CMD_SET_ZOOM",
+    "TCP_CMD_GET_STATUS",
+    "TCP_CMD_STATUS",
+    "PARAM_TABLE",
+    "PARAM_COUNT",
+]

--- a/network/image_stream_icd.py
+++ b/network/image_stream_icd.py
@@ -1,0 +1,46 @@
+"""ICD constants for the Image Stream module."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+CMD_REQ_CAPTURE = 0x01
+CMD_SET_GIMBAL = 0x02  # Reserved
+CMD_SET_COUNT = 0x03
+CMD_GET_IMG_NUM = 0x04
+CMD_REQ_SEND_IMG = 0x05
+CMD_SET_ZOOM_RATIO = 0x06
+CMD_GET_ZOOM_RATIO = 0x07
+
+CMD_IMG_NUM_RESPONSE = 0x11
+CMD_FILE_IMG_TRANSFER = 0x12
+CMD_ACK_ZOOM_RATIO = 0x13
+
+
+COMMAND_NAMES: Dict[int, str] = {
+    CMD_REQ_CAPTURE: "Req_Capture",
+    CMD_SET_GIMBAL: "Set_Gimbal",
+    CMD_SET_COUNT: "Set_Count",
+    CMD_GET_IMG_NUM: "Get_Img_Num",
+    CMD_REQ_SEND_IMG: "Req_Send_Img",
+    CMD_SET_ZOOM_RATIO: "Set_Zoomratio",
+    CMD_GET_ZOOM_RATIO: "Get_Zoomratio",
+    CMD_IMG_NUM_RESPONSE: "Img_Num_Response",
+    CMD_FILE_IMG_TRANSFER: "File_Img_Transfer",
+    CMD_ACK_ZOOM_RATIO: "Ack_Zoomratio",
+}
+
+
+__all__ = [
+    "CMD_REQ_CAPTURE",
+    "CMD_SET_GIMBAL",
+    "CMD_SET_COUNT",
+    "CMD_GET_IMG_NUM",
+    "CMD_REQ_SEND_IMG",
+    "CMD_SET_ZOOM_RATIO",
+    "CMD_GET_ZOOM_RATIO",
+    "CMD_IMG_NUM_RESPONSE",
+    "CMD_FILE_IMG_TRANSFER",
+    "CMD_ACK_ZOOM_RATIO",
+    "COMMAND_NAMES",
+]

--- a/ui/bridge_window.py
+++ b/ui/bridge_window.py
@@ -6,6 +6,9 @@ import logging
 import os
 import tkinter as tk
 from tkinter import ttk, messagebox, StringVar, IntVar
+from typing import Tuple
+
+from ui.gimbal_window import SENSOR_COMBO_VALUES
 
 from utils.settings import ConfigManager, AppConfig  # type: ignore
 
@@ -17,13 +20,14 @@ class BridgeSettingsWindow(tk.Toplevel):
     - 이미지 라이브러리 선택 (Realtime SaveFile / PreDefinedImageSet)
     - Save/Apply
     """
-    def __init__(self, master: tk.Misc, cfg: dict, bridge, log: logging.Logger) -> None:
+    def __init__(self, master: tk.Misc, cfg: dict, bridge, gimbal, log: logging.Logger) -> None:
         super().__init__(master)
         self.title("Image Stream Module Settings")
         self.resizable(False, False)
 
         self.cfg = cfg
         self.bridge = bridge
+        self.gimbal = gimbal
         self.log = log
 
         bconf = cfg.get("bridge", {})
@@ -37,6 +41,11 @@ class BridgeSettingsWindow(tk.Toplevel):
         self.v_predefined_dir = StringVar(
             value=bconf.get("predefined_dir", "./PreDefinedImageSet")
         )
+        self.v_sensor_type = StringVar(value=self._sensor_combo_label(int(bconf.get("gimbal_sensor_type", 0))))
+        self.v_sensor_id = IntVar(value=int(bconf.get("gimbal_sensor_id", 0)))
+        forward_ip, forward_port = self._resolve_gimbal_endpoint()
+        self.v_forward_ip = StringVar(value=forward_ip)
+        self.v_forward_port = IntVar(value=forward_port)
 
         self._build_layout()
         self._bind_events()
@@ -59,9 +68,34 @@ class BridgeSettingsWindow(tk.Toplevel):
         ttk.Label(frm, text="UDP Port").grid(row=2, column=2, sticky="e", **pad)
         ttk.Entry(frm, textvariable=self.v_udp, width=10).grid(row=2, column=3, sticky="w", **pad)
 
-        ttk.Label(frm, text="Image Library Source").grid(row=3, column=0, columnspan=4, sticky="w", pady=(12, 0), padx=6)
+        gimbal_box = ttk.Labelframe(frm, text="Gimbal Forwarding")
+        gimbal_box.grid(row=3, column=0, columnspan=4, sticky="ew", padx=6, pady=(12, 0))
+        ttk.Label(gimbal_box, text="Sensor Type").grid(row=0, column=0, sticky="e", padx=4, pady=2)
+        ttk.Combobox(
+            gimbal_box,
+            textvariable=self.v_sensor_type,
+            values=SENSOR_COMBO_VALUES,
+            state="readonly",
+            width=20,
+        ).grid(row=0, column=1, sticky="w", padx=4, pady=2)
+        ttk.Label(gimbal_box, text="Sensor ID").grid(row=0, column=2, sticky="e", padx=4, pady=2)
+        ttk.Entry(gimbal_box, textvariable=self.v_sensor_id, width=8).grid(row=0, column=3, sticky="w", padx=4, pady=2)
+
+        ttk.Label(gimbal_box, text="Target IP").grid(row=1, column=0, sticky="e", padx=4, pady=2)
+        ttk.Entry(gimbal_box, textvariable=self.v_forward_ip, width=18, state="readonly").grid(row=1, column=1, sticky="w", padx=4, pady=2)
+        ttk.Label(gimbal_box, text="Target Port").grid(row=1, column=2, sticky="e", padx=4, pady=2)
+        ttk.Entry(gimbal_box, textvariable=self.v_forward_port, width=8, state="readonly").grid(row=1, column=3, sticky="w", padx=4, pady=2)
+
+        ttk.Label(
+            gimbal_box,
+            text="IP/Port 변경은 Gimbal Controls 창에서 수행해주세요.",
+            foreground="#555555",
+            wraplength=320,
+        ).grid(row=2, column=0, columnspan=4, sticky="w", padx=4, pady=(0, 4))
+
+        ttk.Label(frm, text="Image Library Source").grid(row=4, column=0, columnspan=4, sticky="w", pady=(12, 0), padx=6)
         mode_frame = ttk.Frame(frm)
-        mode_frame.grid(row=4, column=0, columnspan=4, sticky="w", padx=6)
+        mode_frame.grid(row=5, column=0, columnspan=4, sticky="w", padx=6)
         ttk.Radiobutton(
             mode_frame,
             text="Use Realtime ImageSet (SaveFile)",
@@ -75,17 +109,17 @@ class BridgeSettingsWindow(tk.Toplevel):
             variable=self.v_mode,
         ).grid(row=1, column=0, sticky="w", pady=(2, 0))
 
-        ttk.Label(frm, text="SaveFile Dir").grid(row=5, column=0, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_realtime_dir, width=30).grid(row=5, column=1, sticky="w", **pad)
-        ttk.Label(frm, text="PreDefined Dir").grid(row=5, column=2, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_predefined_dir, width=30).grid(row=5, column=3, sticky="w", **pad)
+        ttk.Label(frm, text="SaveFile Dir").grid(row=6, column=0, sticky="e", **pad)
+        ttk.Entry(frm, textvariable=self.v_realtime_dir, width=30).grid(row=6, column=1, sticky="w", **pad)
+        ttk.Label(frm, text="PreDefined Dir").grid(row=6, column=2, sticky="e", **pad)
+        ttk.Entry(frm, textvariable=self.v_predefined_dir, width=30).grid(row=6, column=3, sticky="w", **pad)
 
-        ttk.Separator(frm, orient=tk.HORIZONTAL).grid(row=6, column=0, columnspan=4, sticky="ew", pady=(8, 8))
+        ttk.Separator(frm, orient=tk.HORIZONTAL).grid(row=7, column=0, columnspan=4, sticky="ew", pady=(8, 8))
         self.lbl_status = ttk.Label(frm, text="Status: -")
-        self.lbl_status.grid(row=7, column=0, columnspan=4, sticky="w", **pad)
+        self.lbl_status.grid(row=8, column=0, columnspan=4, sticky="w", **pad)
 
         btns = ttk.Frame(frm)
-        btns.grid(row=8, column=0, columnspan=4, sticky="e", **pad)
+        btns.grid(row=9, column=0, columnspan=4, sticky="e", **pad)
         ttk.Button(btns, text="Save", command=self.on_save).grid(row=0, column=0, padx=6)
         ttk.Button(btns, text="Apply & Close", command=self.on_apply_close).grid(row=0, column=1, padx=6)
 
@@ -104,6 +138,7 @@ class BridgeSettingsWindow(tk.Toplevel):
         udp = self.v_udp.get()
         mode = self.v_mode.get() or "realtime"
         active_dir = self.v_realtime_dir.get() if mode == "realtime" else self.v_predefined_dir.get()
+        self._refresh_gimbal_endpoint()
         self.lbl_status.configure(
             text=(
                 f"Status: {'Running' if running else 'Stopped'} | {ip} / TCP:{tcp} UDP:{udp}"
@@ -135,6 +170,12 @@ class BridgeSettingsWindow(tk.Toplevel):
                 except Exception as e:
                     raise ValueError(f"Failed to create directory {p}: {e}")
 
+        sensor_type = self._sensor_code_from_combo(self.v_sensor_type.get())
+        try:
+            sensor_id = int(self.v_sensor_id.get())
+        except Exception:
+            raise ValueError("Sensor ID must be an integer value.")
+
         return {
             "ip": ip,
             "tcp_port": tcp,
@@ -143,6 +184,8 @@ class BridgeSettingsWindow(tk.Toplevel):
             "predefined_dir": predefined_dir,
             "image_source_mode": mode,
             "images": realtime_dir,  # legacy 호환
+            "gimbal_sensor_type": sensor_type,
+            "gimbal_sensor_id": sensor_id,
         }
 
     def _apply_to_runtime(self) -> None:
@@ -150,6 +193,9 @@ class BridgeSettingsWindow(tk.Toplevel):
         self.cfg.setdefault("bridge", {}).update(values)
         try:
             self.bridge.update_settings(self.cfg["bridge"])
+            self.bridge.configure_gimbal_forwarding(
+                values["gimbal_sensor_type"], values["gimbal_sensor_id"]
+            )
             self._refresh_status()
         except Exception as e:
             messagebox.showerror("Error", f"Image Stream Module apply failed:\n{e}")
@@ -171,3 +217,31 @@ class BridgeSettingsWindow(tk.Toplevel):
     def on_apply_close(self) -> None:
         self._apply_to_runtime()
         self.destroy()
+
+    def _sensor_combo_label(self, code: int) -> str:
+        if 0 <= code < len(SENSOR_COMBO_VALUES):
+            return SENSOR_COMBO_VALUES[code]
+        return SENSOR_COMBO_VALUES[0]
+
+    def _sensor_code_from_combo(self, combo: str) -> int:
+        try:
+            token = (combo or "0").split(":", 1)[0]
+            return int(token)
+        except Exception:
+            return 0
+
+    def _resolve_gimbal_endpoint(self) -> Tuple[str, int]:
+        if self.gimbal is not None:
+            try:
+                return self.gimbal.get_generator_endpoint()
+            except Exception:
+                pass
+        gimbal_cfg = self.cfg.get("gimbal", {})
+        ip = str(gimbal_cfg.get("generator_ip", "127.0.0.1"))
+        port = int(gimbal_cfg.get("generator_port", 15020))
+        return ip, port
+
+    def _refresh_gimbal_endpoint(self) -> None:
+        ip, port = self._resolve_gimbal_endpoint()
+        self.v_forward_ip.set(ip)
+        self.v_forward_port.set(port)

--- a/ui/bridge_window.py
+++ b/ui/bridge_window.py
@@ -6,7 +6,7 @@ import logging
 import os
 import tkinter as tk
 from tkinter import ttk, messagebox, StringVar, IntVar
-from typing import Tuple
+from typing import Tuple, Optional
 
 from ui.gimbal_window import SENSOR_COMBO_VALUES
 
@@ -20,7 +20,15 @@ class BridgeSettingsWindow(tk.Toplevel):
     - 이미지 라이브러리 선택 (Realtime SaveFile / PreDefinedImageSet)
     - Save/Apply
     """
-    def __init__(self, master: tk.Misc, cfg: dict, bridge, gimbal, log: logging.Logger) -> None:
+    def __init__(
+        self,
+        master: tk.Misc,
+        cfg: dict,
+        bridge,
+        log: logging.Logger,
+        *,
+        gimbal: Optional[object] = None,
+    ) -> None:
         super().__init__(master)
         self.title("Image Stream Module Settings")
         self.resizable(False, False)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -287,7 +287,13 @@ class MainWindow(tk.Tk):
     def open_bridge_window(self) -> None:
         try:
             from ui.bridge_window import BridgeSettingsWindow
-            BridgeSettingsWindow(self, self.cfg, self.bridge, self.gimbal, self.log)
+            BridgeSettingsWindow(
+                self,
+                self.cfg,
+                self.bridge,
+                self.log,
+                gimbal=self.gimbal,
+            )
         except Exception as e:
             messagebox.showerror("Error", f"Open Image Stream Module window failed:\n{e}")
 

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -10,9 +10,11 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 
 try:
-    from typing import Optional, Dict, Any
+    from typing import Optional, Dict, Any, Callable
 except Exception:
-    Optional = Dict = Any = object  # type: ignore
+    Optional = Dict = Any = Callable = object  # type: ignore
+
+from utils.observers import ObservableFloat
 
 
 
@@ -25,7 +27,15 @@ class MainWindow(tk.Tk):
     - 주기적 상태 표시 업데이트
     """
 
-    def __init__(self, cfg, bridge, gimbal, relay, log):
+    def __init__(
+        self,
+        cfg,
+        bridge,
+        gimbal,
+        relay,
+        log,
+        zoom_state: Optional[ObservableFloat] = None,
+    ):
         super().__init__()
         self.title("Unified Bridge")
         self.geometry("1000x700")
@@ -35,13 +45,23 @@ class MainWindow(tk.Tk):
         self.gimbal = gimbal
         self.relay = relay
         self.log = log
+        self.zoom_state = zoom_state
+        self._zoom_unsubscribe: Optional[Callable[[], None]] = None
 
         # 프리뷰 상태 변수
         self._last_photo = None
         self._last_img_ts = 0.0
         self._preview_paused = False
 
+        self.bridge_status_var = tk.StringVar(value="Image Stream Module: Stopped (Realtime)")
+        self.gimbal_status_var = tk.StringVar(value="Gimbal: Deactivated")
+        self.relay_status_var = tk.StringVar(value="Relay: Deactivated")
+        self.preview_info_var = tk.StringVar(value="Last: - | Size: -")
+        self.zoom_var = tk.StringVar(value="Zoom: 1.00x")
+
         self._build_layout()
+        self._bind_events()
+        self._init_zoom_subscription()
 
         # ✅ 브릿지에 프리뷰 콜백 등록 (GUI 모드에서만)
         try:
@@ -67,19 +87,19 @@ class MainWindow(tk.Tk):
         self.btn_bridge = ttk.Button(top, text="Image Stream Module Settings", command=self.open_bridge_window)
         self.btn_bridge.grid(row=0, column=1, padx=(0, 16), pady=4, sticky="w")
 
-        self.lbl_bridge = ttk.Label(top, text="Image Stream Module: Stopped (Realtime)")
+        self.lbl_bridge = ttk.Label(top, textvariable=self.bridge_status_var)
         self.lbl_bridge.grid(row=0, column=2, padx=(0, 16), sticky="w")
 
         self.btn_gimbal = ttk.Button(top, text="Gimbal Controls", command=self.open_gimbal_window)
         self.btn_gimbal.grid(row=1, column=0, padx=(0, 8), pady=4, sticky="w")
 
-        self.lbl_gimbal = ttk.Label(top, text="Gimbal: Deactivated")
+        self.lbl_gimbal = ttk.Label(top, textvariable=self.gimbal_status_var)
         self.lbl_gimbal.grid(row=1, column=2, padx=(0, 16), sticky="w")
 
         self.btn_relay = ttk.Button(top, text="Gazebo Relay Settings", command=self.open_relay_window)
         self.btn_relay.grid(row=2, column=0, padx=(0, 8), pady=4, sticky="w")
 
-        self.lbl_relay = ttk.Label(top, text="Relay: Deactivated")
+        self.lbl_relay = ttk.Label(top, textvariable=self.relay_status_var)
         self.lbl_relay.grid(row=2, column=2, padx=(0, 16), sticky="w")
 
         # ───────── Preview 영역 ─────────
@@ -94,8 +114,10 @@ class MainWindow(tk.Tk):
         right.pack(side=tk.RIGHT, fill=tk.Y)
         right.pack_propagate(False)
 
-        self.lbl_preview_info = ttk.Label(right, text="Last: - | Size: -", anchor="w")
-        self.lbl_preview_info.pack(fill=tk.X, pady=(0, 6))
+        self.lbl_preview_info = ttk.Label(right, textvariable=self.preview_info_var, anchor="w")
+        self.lbl_preview_info.pack(fill=tk.X, pady=(0, 2))
+
+        ttk.Label(right, textvariable=self.zoom_var, anchor="w").pack(fill=tk.X, pady=(0, 6))
 
         btns = ttk.Frame(right)
         btns.pack(fill=tk.X, pady=6)
@@ -105,6 +127,29 @@ class MainWindow(tk.Tk):
         self.log_text = tk.Text(right, height=20, wrap="word")
         self.log_text.pack(fill=tk.BOTH, expand=True, pady=(8,0))
         self.log_text.insert("end", "Logs will appear in console.\n")
+
+    def _init_zoom_subscription(self) -> None:
+        if not self.zoom_state:
+            return
+
+        def _callback(value: float) -> None:
+            self._queue_zoom_update(value)
+
+        self._zoom_unsubscribe = self.zoom_state.subscribe(_callback)
+
+    def _queue_zoom_update(self, value: float) -> None:
+        def _apply() -> None:
+            self._update_zoom_label(value)
+
+        # Tkinter calls must run on the main thread
+        self.after(0, _apply)
+
+    def _update_zoom_label(self, value: float) -> None:
+        try:
+            zoom = float(value)
+        except Exception:
+            zoom = 1.0
+        self.zoom_var.set(f"Zoom: {zoom:.2f}x")
 
     def on_preview(self, jpeg_bytes: bytes):
         """
@@ -131,7 +176,7 @@ class MainWindow(tk.Tk):
 
                 kb = len(jpeg_bytes) / 1024.0
                 tstr = time.strftime("%H:%M:%S", time.localtime(self._last_img_ts))
-                self.lbl_preview_info.configure(text=f"Last: {tstr} | Size: {kb:.1f} KB")
+                self.preview_info_var.set(f"Last: {tstr} | Size: {kb:.1f} KB")
             except Exception as e:
                 self.preview_label.configure(text=f"Preview error: {e}", image="")
                 self.preview_label.image = None
@@ -193,6 +238,9 @@ class MainWindow(tk.Tk):
                 act = st.get("activated", False)
                 mode = st.get("control_mode", "IDLE")
                 self._set_gimbal_status(f"{'Activated' if act else 'Deactivated'} ({mode})")
+                zoom_val = st.get("zoom_scale")
+                if isinstance(zoom_val, (int, float)):
+                    self._update_zoom_label(float(zoom_val))
             else:
                 self._set_gimbal_status("Unknown")
 
@@ -211,13 +259,13 @@ class MainWindow(tk.Tk):
             display = f"{text} ({mode.capitalize()})"
         else:
             display = text
-        self.lbl_bridge.configure(text=f"Image Stream Module: {display}")
+        self.bridge_status_var.set(f"Image Stream Module: {display}")
 
     def _set_gimbal_status(self, text: str) -> None:
-        self.lbl_gimbal.configure(text=f"Gimbal: {text}")
+        self.gimbal_status_var.set(f"Gimbal: {text}")
 
     def _set_relay_status(self, text: str) -> None:
-        self.lbl_relay.configure(text=f"Relay: {text}")
+        self.relay_status_var.set(f"Relay: {text}")
 
     # ---------------- 버튼 동작 ----------------
 
@@ -239,7 +287,7 @@ class MainWindow(tk.Tk):
     def open_bridge_window(self) -> None:
         try:
             from ui.bridge_window import BridgeSettingsWindow
-            BridgeSettingsWindow(self, self.cfg, self.bridge, self.log)
+            BridgeSettingsWindow(self, self.cfg, self.bridge, self.gimbal, self.log)
         except Exception as e:
             messagebox.showerror("Error", f"Open Image Stream Module window failed:\n{e}")
 
@@ -260,12 +308,24 @@ class MainWindow(tk.Tk):
     # ---------------- 종료 ----------------
 
     def on_close(self) -> None:
+        if self._zoom_unsubscribe:
+            try:
+                self._zoom_unsubscribe()
+            except Exception:
+                pass
         try:
             self.destroy()
         except Exception:
             pass
 
 
-def run_gui(cfg: dict, bridge, gimbal, relay, log: logging.Logger) -> None:
-    app = MainWindow(cfg, bridge, gimbal, relay, log)
+def run_gui(
+    cfg: dict,
+    bridge,
+    gimbal,
+    relay,
+    log: logging.Logger,
+    zoom_state: Optional[ObservableFloat] = None,
+) -> None:
+    app = MainWindow(cfg, bridge, gimbal, relay, log, zoom_state=zoom_state)
     app.mainloop()

--- a/utils/observers.py
+++ b/utils/observers.py
@@ -1,0 +1,74 @@
+"""Observable helpers for sharing runtime state between modules."""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable, Generic, List, TypeVar
+
+T = TypeVar("T")
+
+
+class ObservableValue(Generic[T]):
+    """Thread-safe observable value container."""
+
+    def __init__(self, initial: T) -> None:
+        self._value = initial
+        self._lock = threading.Lock()
+        self._observers: List[Callable[[T], None]] = []
+
+    def subscribe(
+        self,
+        callback: Callable[[T], None],
+        *,
+        notify_immediately: bool = True,
+    ) -> Callable[[], None]:
+        """Register *callback* and return an unsubscribe function."""
+
+        with self._lock:
+            self._observers.append(callback)
+            current = self._value
+
+        if notify_immediately:
+            try:
+                callback(current)
+            except Exception:
+                # Observers should handle their own errors; ignore to keep others notified.
+                pass
+
+        def _unsubscribe() -> None:
+            self.unsubscribe(callback)
+
+        return _unsubscribe
+
+    def unsubscribe(self, callback: Callable[[T], None]) -> None:
+        with self._lock:
+            self._observers = [cb for cb in self._observers if cb is not callback]
+
+    def set(self, value: T) -> None:
+        with self._lock:
+            self._value = value
+            observers = list(self._observers)
+
+        for cb in observers:
+            try:
+                cb(value)
+            except Exception:
+                pass
+
+    def get(self) -> T:
+        with self._lock:
+            return self._value
+
+    @property
+    def value(self) -> T:
+        return self.get()
+
+
+class ObservableFloat(ObservableValue[float]):
+    """Observable that normalises values to ``float`` before broadcasting."""
+
+    def set(self, value: float) -> None:  # type: ignore[override]
+        super().set(float(value))
+
+
+__all__ = ["ObservableValue", "ObservableFloat"]

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -196,6 +196,8 @@ class AppConfig:
         # req_capture / get_imgnum 페이로드 정책
         b.setdefault("use_1byte_payload_for_rcv", True)
         b.setdefault("zoom_scale", 1.0)
+        b.setdefault("gimbal_sensor_type", 0)
+        b.setdefault("gimbal_sensor_id", 0)
 
         # Gimbal 기본값
         g = self.gimbal


### PR DESCRIPTION
## Summary
- forward the Set_Gimbal TCP command from the image stream module to the gimbal control so incoming requests move the camera
- expose configuration for the forwarded sensor type/ID in the image stream settings window and show the gimbal network target read-only with guidance
- sync defaults/CLI/config documentation for the new gimbal forwarding settings

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e0c5ea551c83258c8dd5fc387d7df6