### PR TITLE
Stream logs to GUI and add gimbal packet dump option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ pyinstaller --noconfirm --clean --name MroUnifiedBridge \
 ## Sensor Control ICD
 
 ### UDP (Generator Forward)
-- **10706 SensorGimbalCtrl**: `<uint16 sensor_type><uint16 sensor_id><float64 pos_x><float64 pos_y><float64 pos_z><float32 roll_deg><float32 pitch_deg><float32 yaw_deg>` (little-endian)
+- **10706 SensorGimbalCtrl**: `<uint8 sensor_type><uint8 sensor_id><float64 pos_x><float64 pos_y><float64 pos_z><float32 quat_x><float32 quat_y><float32 quat_z><float32 quat_w>` (little-endian)
 - **10707 SensorPowerCtrl**: `<uint16 sensor_type><uint16 sensor_id><uint8 power_on>`
 
 ### TCP `MroCameraControl` Command Set

--- a/main.py
+++ b/main.py
@@ -64,6 +64,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--gen-port", type=int, help="Generator port for 10706.")
     p.add_argument("--sensor-type", type=int, help="Sensor type code (0:Camera,1:GPS,2:LiDAR,3:RADAR,4:LRF,5:IMU).")
     p.add_argument("--sensor-id", type=int, help="Sensor ID.")
+    p.add_argument(
+        "--show-gimbal-packets",
+        action="store_true",
+        help="Display the packed 10706 gimbal control bytes in the GUI log window.",
+    )
 
     # (Optional) Relay overrides
     p.add_argument("--relay-bind-ip", type=str, help="Relay input bind IP.")
@@ -146,6 +151,7 @@ def apply_cli_overrides(args: argparse.Namespace, cfg: Dict[str, Any]) -> None:
     if args.gen_port is not None:        g["generator_port"] = int(args.gen_port)
     if args.sensor_type is not None:     g["sensor_type"] = int(args.sensor_type)
     if args.sensor_id is not None:       g["sensor_id"] = int(args.sensor_id)
+    if args.show_gimbal_packets:         g["debug_dump_packets"] = True
     if args.sensor_type is not None:
         b["gimbal_sensor_type"] = int(args.sensor_type)
     if args.sensor_id is not None:


### PR DESCRIPTION
## Summary
- mirror the unified bridge logger into the GUI log text area through a Tk text handler
- add a --show-gimbal-packets flag that enables hex dumps of packed gimbal control payloads
- emit optional packet hex dumps for both background pose updates and preset sends when debugging is enabled

## Testing
- python -m compileall core ui utils network

------
https://chatgpt.com/codex/tasks/task_e_68f1ccf66974832597f5f5b16f8e8038