### PR TITLE
Remove rover command relay and reorder logging

### DIFF
--- a/core/log_parsers.py
+++ b/core/log_parsers.py
@@ -1,0 +1,163 @@
+"""CSV helpers for the unified drone/rover log format."""
+
+from __future__ import annotations
+
+import math
+import struct
+import time
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+
+UNIFIED_CSV_HEADER = (
+    "time_usec,position_x,position_y,position_z,"
+    "orientation_w,orientation_x,orientation_y,orientation_z,"
+    "angular_velocity_x,angular_velocity_y,angular_velocity_z"
+)
+
+
+def _format_float(value: float) -> str:
+    """Format floats for CSV output, preserving NaN semantics."""
+
+    if math.isnan(value):
+        return "NaN"
+    if math.isinf(value):
+        return "inf" if value > 0 else "-inf"
+    return f"{value:.9f}".rstrip("0").rstrip(".") or "0"
+
+
+def _utc_timestamp_usec() -> int:
+    """Return the current UTC timestamp in microseconds."""
+
+    return time.time_ns() // 1000
+
+
+def format_unified_row(
+    *,
+    time_usec: int,
+    position: Sequence[float],
+    orientation_wxyz: Sequence[float],
+    angular_velocity: Sequence[float],
+) -> str:
+    """Format a row that matches :data:`UNIFIED_CSV_HEADER`."""
+
+    px, py, pz = position
+    ow, ox, oy, oz = orientation_wxyz
+    avx, avy, avz = angular_velocity
+    fields: Iterable[str] = (
+        str(int(time_usec)),
+        _format_float(float(px)),
+        _format_float(float(py)),
+        _format_float(float(pz)),
+        _format_float(float(ow)),
+        _format_float(float(ox)),
+        _format_float(float(oy)),
+        _format_float(float(oz)),
+        _format_float(float(avx)),
+        _format_float(float(avy)),
+        _format_float(float(avz)),
+    )
+    return ",".join(fields)
+
+
+def format_drone_csv_row(
+    *,
+    time_usec: int,
+    position: Sequence[float],
+    orientation_wxyz: Sequence[float],
+    angular_velocity: Sequence[float],
+) -> str:
+    """Expose the drone ghost-mode payload using the unified CSV layout."""
+
+    return format_unified_row(
+        time_usec=time_usec,
+        position=position,
+        orientation_wxyz=orientation_wxyz,
+        angular_velocity=angular_velocity,
+    )
+
+
+@dataclass
+class RoverFeedbackCsvFormatter:
+    """Stateful formatter that maps rover feedback packets to CSV rows."""
+
+    _last_time_usec: int | None = None
+    _last_position: tuple[float, float, float] | None = None
+
+    def reset(self) -> None:
+        """Clear cached state so subsequent packets start fresh."""
+
+        self._last_time_usec = None
+        self._last_position = None
+
+    def format_packet(self, data: bytes) -> str:
+        """Convert a rover feedback packet into the unified CSV layout."""
+
+        if len(data) < 26:
+            raise ValueError("rover feedback packet too short")
+        if data[0:2] != b"PU":
+            raise ValueError("invalid rover feedback packet signature")
+
+        # Parse payload per ICD (little-endian floats/ints).
+        x, y, z, heading_deg = struct.unpack_from("<ffff", data, 5)
+        velocity_raw = struct.unpack_from("<b", data, 21)[0]
+
+        # Convert timestamp immediately to support derivative fallbacks.
+        time_usec = _utc_timestamp_usec()
+
+        # Position expressed in metres in the aircraft-aligned frame.
+        position = (float(x), float(y), float(z))
+
+        # Orientation: heading is defined clockwise from north with +Z up.
+        heading_rad_clockwise = math.radians(float(heading_deg) % 360.0)
+        yaw_rad = -heading_rad_clockwise  # Convert to right-handed CCW convention.
+        half_yaw = yaw_rad / 2.0
+        orientation = (
+            math.cos(half_yaw),  # w
+            0.0,  # x
+            0.0,  # y
+            math.sin(half_yaw),  # z
+        )
+
+        # Velocity is supplied in 0.1 KPH units.
+        speed_mps = float(velocity_raw) * 0.1 * (1000.0 / 3600.0)
+
+        if speed_mps == 0.0 and self._last_time_usec and self._last_position:
+            # Derive a fallback speed from the position delta when the encoded
+            # speed reports zero. This honours the instruction to combine
+            # position and heading when possible.
+            dt = (time_usec - self._last_time_usec) / 1_000_000.0
+            if dt > 0:
+                last_x, last_y, last_z = self._last_position
+                dx = x - last_x
+                dy = y - last_y
+                dz = z - last_z
+                distance = math.sqrt(dx * dx + dy * dy + dz * dz)
+                speed_mps = distance / dt
+
+        # Resolve the horizontal components using the project coordinate system
+        # (+X north, +Y west). The z-component is not provided by the ICD and
+        # must remain NaN as requested.
+        angular_velocity = (
+            speed_mps * math.cos(heading_rad_clockwise),
+            -speed_mps * math.sin(heading_rad_clockwise),
+            math.nan,
+        )
+
+        self._last_time_usec = time_usec
+        self._last_position = position
+
+        return format_unified_row(
+            time_usec=time_usec,
+            position=position,
+            orientation_wxyz=orientation,
+            angular_velocity=angular_velocity,
+        )
+
+
+__all__ = [
+    "UNIFIED_CSV_HEADER",
+    "format_drone_csv_row",
+    "format_unified_row",
+    "RoverFeedbackCsvFormatter",
+]

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -468,51 +468,30 @@ class MainWindow(tk.Tk):
             rover_enabled = bool(rover_status.get("enabled", rover_cfg.get("enabled", True)))
             rover_cfg["enabled"] = rover_enabled
 
-            if "cmd_log_path" in rover_status and rover_status["cmd_log_path"] is not None:
-                rover_cfg["cmd_log_path"] = rover_status["cmd_log_path"]
             if "feedback_log_path" in rover_status and rover_status["feedback_log_path"] is not None:
                 rover_cfg["feedback_log_path"] = rover_status["feedback_log_path"]
 
-            cmd_path = str(rover_cfg.get("cmd_log_path", "") or "")
             fb_path = str(rover_cfg.get("feedback_log_path", "") or "")
-            cmd_active = bool(rover_status.get("cmd_logging_active", False))
             fb_active = bool(rover_status.get("feedback_logging_active", False))
-            cmd_count = rover_status.get("cmd_logged_count")
             fb_count = rover_status.get("feedback_logged_count")
-            cmd_error = rover_status.get("cmd_log_error") or ""
             fb_error = rover_status.get("feedback_log_error") or ""
+
+            rover_cfg.pop("cmd_log_path", None)
 
             if not rover_enabled:
                 rover_text = "Rover Logging: Disabled (Settings)"
-            elif cmd_active or fb_active:
-                parts = []
-                if cmd_active:
-                    if isinstance(cmd_count, (int, float)):
-                        parts.append(f"CMD {int(cmd_count)}")
-                    else:
-                        parts.append("CMD")
-                if fb_active:
-                    if isinstance(fb_count, (int, float)):
-                        parts.append(f"FB {int(fb_count)}")
-                    else:
-                        parts.append("FB")
-                rover_text = f"Rover Logging: Recording ({', '.join(parts)})"
-            elif cmd_error or fb_error:
-                errs = []
-                if cmd_error:
-                    errs.append(f"CMD {cmd_error}")
-                if fb_error:
-                    errs.append(f"FB {fb_error}")
-                rover_text = f"Rover Logging: Error ({'; '.join(errs)})"
-            elif rover_active and not (cmd_path or fb_path):
+            elif fb_active:
+                if isinstance(fb_count, (int, float)):
+                    rover_text = f"Rover Logging: Recording (FB {int(fb_count)})"
+                else:
+                    rover_text = "Rover Logging: Recording (FB)"
+            elif fb_error:
+                rover_text = f"Rover Logging: Error (FB {fb_error})"
+            elif rover_active and not fb_path:
                 rover_text = "Rover Logging: Forwarding (no log path)"
-            elif cmd_path or fb_path:
-                targets = []
-                if cmd_path:
-                    targets.append(f"CMD→{os.path.basename(cmd_path) or cmd_path}")
-                if fb_path:
-                    targets.append(f"FB→{os.path.basename(fb_path) or fb_path}")
-                rover_text = f"Rover Logging: Ready ({', '.join(targets)})"
+            elif fb_path:
+                target = f"FB→{os.path.basename(fb_path) or fb_path}"
+                rover_text = f"Rover Logging: Ready ({target})"
             else:
                 rover_text = "Rover Logging: Idle"
             self.rover_log_status_var.set(rover_text)

--- a/ui/rover_relay_window.py
+++ b/ui/rover_relay_window.py
@@ -11,7 +11,7 @@ from utils.settings import ConfigManager, AppConfig  # type: ignore
 
 
 class RoverRelaySettingsWindow(tk.Toplevel):
-    """Configure rover relay logging for control command and feedback streams."""
+    """Configure rover feedback relay logging."""
 
     def __init__(self, master: tk.Misc, cfg: Dict[str, Any], rover, relay, log) -> None:
         super().__init__(master)
@@ -28,12 +28,6 @@ class RoverRelaySettingsWindow(tk.Toplevel):
         self.v_enabled = tk.BooleanVar(value=bool(rconf.get("enabled", True)))
         self.v_autostart = tk.BooleanVar(value=bool(rconf.get("autostart", False)))
 
-        self.v_cmd_listen_ip = tk.StringVar(value=rconf.get("cmd_listen_ip", "0.0.0.0"))
-        self.v_cmd_listen_port = tk.IntVar(value=int(rconf.get("cmd_listen_port", 18100)))
-        self.v_cmd_dest_ip = tk.StringVar(value=rconf.get("cmd_dest_ip", "127.0.0.1"))
-        self.v_cmd_dest_port = tk.IntVar(value=int(rconf.get("cmd_dest_port", 18101)))
-        self.v_cmd_log = tk.StringVar(value=rconf.get("cmd_log_path", ""))
-
         self.v_fb_listen_ip = tk.StringVar(value=rconf.get("feedback_listen_ip", "0.0.0.0"))
         self.v_fb_listen_port = tk.IntVar(value=int(rconf.get("feedback_listen_port", 18102)))
         self.v_fb_dest_ip = tk.StringVar(value=rconf.get("feedback_dest_ip", "127.0.0.1"))
@@ -49,45 +43,28 @@ class RoverRelaySettingsWindow(tk.Toplevel):
         frm = ttk.Frame(self, padding=12)
         frm.grid(row=0, column=0, sticky="nsew")
 
-        ttk.Label(frm, text="Control Command Relay").grid(row=0, column=0, columnspan=4, sticky="w", **pad)
+        ttk.Label(frm, text="Feedback Relay").grid(row=0, column=0, columnspan=4, sticky="w", **pad)
         ttk.Label(frm, text="Listen IP").grid(row=1, column=0, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_cmd_listen_ip, width=16).grid(row=1, column=1, sticky="w", **pad)
+        ttk.Entry(frm, textvariable=self.v_fb_listen_ip, width=16).grid(row=1, column=1, sticky="w", **pad)
         ttk.Label(frm, text="Port").grid(row=1, column=2, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_cmd_listen_port, width=10).grid(row=1, column=3, sticky="w", **pad)
+        ttk.Entry(frm, textvariable=self.v_fb_listen_port, width=10).grid(row=1, column=3, sticky="w", **pad)
 
         ttk.Label(frm, text="Dest IP").grid(row=2, column=0, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_cmd_dest_ip, width=16).grid(row=2, column=1, sticky="w", **pad)
+        ttk.Entry(frm, textvariable=self.v_fb_dest_ip, width=16).grid(row=2, column=1, sticky="w", **pad)
         ttk.Label(frm, text="Port").grid(row=2, column=2, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_cmd_dest_port, width=10).grid(row=2, column=3, sticky="w", **pad)
+        ttk.Entry(frm, textvariable=self.v_fb_dest_port, width=10).grid(row=2, column=3, sticky="w", **pad)
 
         ttk.Label(frm, text="Log Path").grid(row=3, column=0, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_cmd_log, width=32).grid(row=3, column=1, columnspan=2, sticky="we", **pad)
-        ttk.Button(frm, text="Browse", command=self.on_browse_cmd_log).grid(row=3, column=3, sticky="w", **pad)
+        ttk.Entry(frm, textvariable=self.v_fb_log, width=32).grid(row=3, column=1, columnspan=2, sticky="we", **pad)
+        ttk.Button(frm, text="Browse", command=self.on_browse_fb_log).grid(row=3, column=3, sticky="w", **pad)
 
         ttk.Separator(frm, orient=tk.HORIZONTAL).grid(row=4, column=0, columnspan=4, sticky="ew", pady=(8, 8))
 
-        ttk.Label(frm, text="Feedback Relay").grid(row=5, column=0, columnspan=4, sticky="w", **pad)
-        ttk.Label(frm, text="Listen IP").grid(row=6, column=0, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_fb_listen_ip, width=16).grid(row=6, column=1, sticky="w", **pad)
-        ttk.Label(frm, text="Port").grid(row=6, column=2, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_fb_listen_port, width=10).grid(row=6, column=3, sticky="w", **pad)
-
-        ttk.Label(frm, text="Dest IP").grid(row=7, column=0, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_fb_dest_ip, width=16).grid(row=7, column=1, sticky="w", **pad)
-        ttk.Label(frm, text="Port").grid(row=7, column=2, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_fb_dest_port, width=10).grid(row=7, column=3, sticky="w", **pad)
-
-        ttk.Label(frm, text="Log Path").grid(row=8, column=0, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.v_fb_log, width=32).grid(row=8, column=1, columnspan=2, sticky="we", **pad)
-        ttk.Button(frm, text="Browse", command=self.on_browse_fb_log).grid(row=8, column=3, sticky="w", **pad)
-
-        ttk.Separator(frm, orient=tk.HORIZONTAL).grid(row=9, column=0, columnspan=4, sticky="ew", pady=(8, 8))
-
         ttk.Checkbutton(frm, text="Enable rover relay logging", variable=self.v_enabled).grid(
-            row=10, column=0, columnspan=2, sticky="w", **pad
+            row=5, column=0, columnspan=2, sticky="w", **pad
         )
         ttk.Checkbutton(frm, text="Autostart on launch", variable=self.v_autostart).grid(
-            row=10, column=2, columnspan=2, sticky="w", **pad
+            row=5, column=2, columnspan=2, sticky="w", **pad
         )
 
         note = ttk.Label(
@@ -97,10 +74,10 @@ class RoverRelaySettingsWindow(tk.Toplevel):
             wraplength=380,
             justify="left",
         )
-        note.grid(row=11, column=0, columnspan=4, sticky="w", pady=(4, 8))
+        note.grid(row=6, column=0, columnspan=4, sticky="w", pady=(4, 8))
 
         btns = ttk.Frame(frm)
-        btns.grid(row=12, column=0, columnspan=4, sticky="ew", pady=(4, 4))
+        btns.grid(row=7, column=0, columnspan=4, sticky="ew", pady=(4, 4))
         btns.columnconfigure(0, weight=1)
         ttk.Button(btns, text="Start", command=self.on_start).grid(row=0, column=0, padx=4)
         ttk.Button(btns, text="Stop", command=self.on_stop).grid(row=0, column=1, padx=4)
@@ -109,20 +86,15 @@ class RoverRelaySettingsWindow(tk.Toplevel):
         ttk.Button(btns, text="Close", command=self.destroy).grid(row=0, column=4, padx=4)
 
         self.lbl_status1 = ttk.Label(frm, text="-")
-        self.lbl_status1.grid(row=13, column=0, columnspan=4, sticky="w", **pad)
+        self.lbl_status1.grid(row=8, column=0, columnspan=4, sticky="w", **pad)
         self.lbl_status2 = ttk.Label(frm, text="-")
-        self.lbl_status2.grid(row=14, column=0, columnspan=4, sticky="w", **pad)
+        self.lbl_status2.grid(row=9, column=0, columnspan=4, sticky="w", **pad)
 
     # ------------------------------------------------------------------
     def _collect_values(self) -> Dict[str, Any]:
         return {
             "enabled": bool(self.v_enabled.get()),
             "autostart": bool(self.v_autostart.get()),
-            "cmd_listen_ip": self.v_cmd_listen_ip.get().strip(),
-            "cmd_listen_port": int(self.v_cmd_listen_port.get()),
-            "cmd_dest_ip": self.v_cmd_dest_ip.get().strip(),
-            "cmd_dest_port": int(self.v_cmd_dest_port.get()),
-            "cmd_log_path": self.v_cmd_log.get().strip(),
             "feedback_listen_ip": self.v_fb_listen_ip.get().strip(),
             "feedback_listen_port": int(self.v_fb_listen_port.get()),
             "feedback_dest_ip": self.v_fb_dest_ip.get().strip(),
@@ -133,12 +105,17 @@ class RoverRelaySettingsWindow(tk.Toplevel):
     def _apply_to_runtime(self) -> None:
         values = self._collect_values()
         self.cfg.setdefault("rover", {}).update(values)
+        for obsolete in (
+            "cmd_listen_ip",
+            "cmd_listen_port",
+            "cmd_dest_ip",
+            "cmd_dest_port",
+            "cmd_log_path",
+        ):
+            self.cfg["rover"].pop(obsolete, None)
         self.rover.update_settings(values)
 
     # ------------------------------------------------------------------
-    def on_browse_cmd_log(self) -> None:
-        self._browse_log(self.v_cmd_log, "Select command log file")
-
     def on_browse_fb_log(self) -> None:
         self._browse_log(self.v_fb_log, "Select feedback log file")
 
@@ -186,6 +163,14 @@ class RoverRelaySettingsWindow(tk.Toplevel):
             ac = cm.load()
             data = ac.to_dict()
             data.setdefault("rover", {}).update(self._collect_values())
+            for obsolete in (
+                "cmd_listen_ip",
+                "cmd_listen_port",
+                "cmd_dest_ip",
+                "cmd_dest_port",
+                "cmd_log_path",
+            ):
+                data["rover"].pop(obsolete, None)
             cm.save(AppConfig.from_dict(data))
             messagebox.showinfo("Saved", "Rover relay settings saved.")
         except Exception as e:
@@ -197,24 +182,15 @@ class RoverRelaySettingsWindow(tk.Toplevel):
             status = self.rover.get_status() if hasattr(self.rover, "get_status") else {}
             activated = status.get("activated", False)
             enabled = status.get("enabled", self.v_enabled.get())
-            cmd_log_path = status.get("cmd_log_path") or self.v_cmd_log.get()
             fb_log_path = status.get("feedback_log_path") or self.v_fb_log.get()
-            cmd_active = bool(status.get("cmd_logging_active", False))
             fb_active = bool(status.get("feedback_logging_active", False))
-            cmd_count = status.get("cmd_logged_count")
             fb_count = status.get("feedback_logged_count")
-            cmd_err = status.get("cmd_log_error") or ""
             fb_err = status.get("feedback_log_error") or ""
 
             parts = [
                 f"Status: {'Running' if activated else 'Stopped'}",
                 f"Enabled: {'Yes' if enabled else 'No'}",
             ]
-            if cmd_active:
-                if isinstance(cmd_count, (int, float)):
-                    parts.append(f"CMD logged {int(cmd_count)}")
-                else:
-                    parts.append("CMD logging")
             if fb_active:
                 if isinstance(fb_count, (int, float)):
                     parts.append(f"FB logged {int(fb_count)}")
@@ -223,14 +199,10 @@ class RoverRelaySettingsWindow(tk.Toplevel):
             self.lbl_status1.configure(text=" | ".join(parts))
 
             msg = []
-            if cmd_err:
-                msg.append(f"CMD error: {cmd_err}")
             if fb_err:
                 msg.append(f"FB error: {fb_err}")
             if not msg:
                 paths = []
-                if cmd_log_path:
-                    paths.append(f"CMD→{os.path.basename(cmd_log_path) or cmd_log_path}")
                 if fb_log_path:
                     paths.append(f"FB→{os.path.basename(fb_log_path) or fb_log_path}")
                 if paths:

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -304,14 +304,6 @@ class AppConfig:
         rv = self.rover
         rv.setdefault("enabled", True)
         rv.setdefault("autostart", False)
-        rv.setdefault("cmd_listen_ip", "0.0.0.0")
-        rv.setdefault("cmd_listen_port", 18100)
-        rv.setdefault("cmd_dest_ip", "127.0.0.1")
-        rv.setdefault("cmd_dest_port", 18101)
-        rv.setdefault(
-            "cmd_log_path",
-            os.path.join(get_default_save_dir(), "rover_command_messages.txt"),
-        )
         rv.setdefault("feedback_listen_ip", "0.0.0.0")
         rv.setdefault("feedback_listen_port", 18102)
         rv.setdefault("feedback_dest_ip", "127.0.0.1")
@@ -320,10 +312,17 @@ class AppConfig:
             "feedback_log_path",
             os.path.join(get_default_save_dir(), "rover_feedback_messages.txt"),
         )
-        for key in ("cmd_log_path", "feedback_log_path"):
-            path = rv.get(key)
-            if path:
-                ensure_dir(os.path.dirname(path))
+        for obsolete in (
+            "cmd_listen_ip",
+            "cmd_listen_port",
+            "cmd_dest_ip",
+            "cmd_dest_port",
+            "cmd_log_path",
+        ):
+            rv.pop(obsolete, None)
+        path = rv.get("feedback_log_path")
+        if path:
+            ensure_dir(os.path.dirname(path))
 
     # ---------- 편의 메서드 ----------
 


### PR DESCRIPTION
## Summary
- drop rover command relay sockets, logs, and UI fields so the feature focuses solely on feedback forwarding and CSV capture
- reorder the feedback handling loop to forward each packet before writing to disk and simplify status reporting in the UI
- clean legacy rover command keys from settings defaults and saved configurations

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68fa1216d7f883258efdab586bbc5da4