### PR TITLE
Ensure UI zoom label follows bridge status

### DIFF
--- a/main.py
+++ b/main.py
@@ -224,15 +224,6 @@ def main() -> None:
     relay_log  = make_log_cb(log, "[RELAY]")
     rover_log  = make_log_cb(log, "[ROVER]")
 
-    bridge_cfg = cfg_dict.get("bridge", {})
-
-    bridge = ImageStreamBridge(
-        log_cb=bridge_log,
-        preview_cb=None,  # GUI 미리보기는 UI 쪽에서 연결
-        status_cb=make_status_cb(log, "BRIDGE"),
-        settings=bridge_cfg,
-    )
-
     gimbal_cfg = cfg_dict.get("gimbal", {})
     method = str(gimbal_cfg.get("control_method", "tcp")).lower()
     if method not in ("tcp", "mavlink"):
@@ -243,6 +234,17 @@ def main() -> None:
     except (TypeError, ValueError):
         initial_zoom = 1.0
     zoom_state = ObservableFloat(initial_zoom)
+
+    bridge_cfg = cfg_dict.get("bridge", {})
+
+    bridge = ImageStreamBridge(
+        log_cb=bridge_log,
+        preview_cb=None,  # GUI 미리보기는 UI 쪽에서 연결
+        status_cb=make_status_cb(log, "BRIDGE"),
+        settings=bridge_cfg,
+        zoom_update_cb=zoom_state.set,
+    )
+
     zoom_state.subscribe(bridge.set_zoom_scale)
 
     gimbal = GimbalControl(
@@ -252,7 +254,6 @@ def main() -> None:
         zoom_update_cb=zoom_state.set,
     )
 
-    bridge.register_zoom_update_callback(zoom_state.set)
     bridge.attach_gimbal_controller(gimbal)
     try:
         sensor_type = int(bridge_cfg.get("gimbal_sensor_type", 0))

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -387,11 +387,12 @@ class MainWindow(tk.Tk):
                 text="Stop Image Stream Module" if running else "Start Image Stream Module"
             )
 
-            bridge_zoom = bridge_status.get("zoom_scale")
-            if isinstance(bridge_zoom, (int, float)):
-                zoom_value = float(bridge_zoom)
-                if (not self.zoom_state) or abs(zoom_value - self._current_zoom_value) > 1e-3:
-                    self._update_zoom_label(zoom_value)
+            if not self.zoom_state:
+                bridge_zoom = bridge_status.get("zoom_scale")
+                if isinstance(bridge_zoom, (int, float)):
+                    zoom_value = float(bridge_zoom)
+                    if abs(zoom_value - self._current_zoom_value) > 1e-3:
+                        self._update_zoom_label(zoom_value)
 
             # Gimbal 상태
             if hasattr(self.gimbal, "get_status"):
@@ -412,9 +413,10 @@ class MainWindow(tk.Tk):
                     if cfg_method in ("tcp", "mavlink") and self.gimbal_control_method_var.get() != cfg_method:
                         self.gimbal_control_method_var.set(cfg_method)
                 self._set_gimbal_status(f"{'Activated' if act else 'Deactivated'} ({display})")
-                zoom_val = st.get("zoom_scale")
-                if isinstance(zoom_val, (int, float)):
-                    self._update_zoom_label(float(zoom_val))
+                if not self.zoom_state:
+                    zoom_val = st.get("zoom_scale")
+                    if isinstance(zoom_val, (int, float)):
+                        self._update_zoom_label(float(zoom_val))
             else:
                 self._set_gimbal_status("Unknown")
 

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -374,14 +374,24 @@ class MainWindow(tk.Tk):
     def _refresh_status_periodic(self) -> None:
         try:
             running = getattr(self.bridge, "is_server_running", None) and self.bridge.is_server_running.is_set()
+            bridge_status: Dict[str, Any] = {}
             try:
-                mode = self.bridge.get_runtime_status().get("image_source_mode")
+                status_obj = self.bridge.get_runtime_status()
+                if isinstance(status_obj, dict):
+                    bridge_status = status_obj
             except Exception:
-                mode = None
+                bridge_status = {}
+            mode = bridge_status.get("image_source_mode")
             self._set_bridge_status("Running" if running else "Stopped", mode)
             self.btn_server.configure(
                 text="Stop Image Stream Module" if running else "Start Image Stream Module"
             )
+
+            bridge_zoom = bridge_status.get("zoom_scale")
+            if isinstance(bridge_zoom, (int, float)):
+                zoom_value = float(bridge_zoom)
+                if (not self.zoom_state) or abs(zoom_value - self._current_zoom_value) > 1e-3:
+                    self._update_zoom_label(zoom_value)
 
             # Gimbal 상태
             if hasattr(self.gimbal, "get_status"):


### PR DESCRIPTION
## Summary
- refresh the main window zoom indicator from the bridge runtime status so the preview info reflects TCP zoom changes even if observers miss the callback

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68fa36fb7ba083259572e4b5e41d75d9