### PR TITLE
Handle transient rover relay socket errors gracefully

### DIFF
--- a/core/rover_relay_logger.py
+++ b/core/rover_relay_logger.py
@@ -393,12 +393,19 @@ class RoverRelayLogger:
                 break
             try:
                 size, _ = sock.recvfrom_into(view)
-            except OSError:
-                break
+            except OSError as exc:
+                if self._stop_ev.is_set():
+                    break
+                self._log_status(f"feedback recv error: {exc}")
+                with lock:
+                    setattr(self, error_attr, str(exc))
+                time.sleep(0.01)
+                continue
             except Exception as e:  # noqa: BLE001
                 self._log_status(f"feedback recv error: {e}")
                 with lock:
                     setattr(self, error_attr, str(e))
+                time.sleep(0.01)
                 continue
 
             if size <= 0:

--- a/core/udp_relay.py
+++ b/core/udp_relay.py
@@ -699,8 +699,12 @@ class UdpRelay:
                 break
             try:
                 size, _ = sock.recvfrom_into(view)
-            except OSError:
-                break
+            except OSError as exc:
+                if self.stop_ev.is_set():
+                    break
+                self.log(f"[RELAY] gazebo recv error: {exc}")
+                time.sleep(0.01)
+                continue
             except Exception as e:
                 self.log(f"[RELAY] gazebo loop error: {e}")
                 continue
@@ -849,8 +853,12 @@ class UdpRelay:
                     rx_cnt = 0
                     last_log = time.time()
 
-            except OSError:
-                break
+            except OSError as exc:
+                if self.stop_ev.is_set():
+                    break
+                self.log(f"[RELAY] distance raw udp recv error: {exc}")
+                time.sleep(0.01)
+                continue
             except Exception as e:
                 self.log(f"[RELAY] distance raw udp error: {e}")
 


### PR DESCRIPTION
## Summary
- keep the rover relay feedback loop alive when recvfrom raises transient socket errors
- continue relaying and logging immediately once feedback resumes without requiring a manual restart

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68fa52a6d5b883258f834066ab01e2be