### PR TITLE
Throttle camera preview updates to keep GUI responsive

### DIFF
--- a/utils/settings.py
+++ b/utils/settings.py
@@ -196,6 +196,7 @@ class AppConfig:
         # GUI 미리보기 등
         b.setdefault("console_echo", True)         # 콘솔 로그 echo
         b.setdefault("show_hud", True)             # (옵션) 간단 상태 표시
+        b.setdefault("preview_min_interval", 0.2)  # GUI 미리보기 프레임 최소 간격 (초)
         # req_capture / get_imgnum 페이로드 정책
         b.setdefault("use_1byte_payload_for_rcv", True)
         b.setdefault("zoom_scale", 1.0)


### PR DESCRIPTION
## Summary
- throttle the image bridge preview callback so frames are only forwarded at a configurable interval
- guard the Tk preview handler to drop frames while a decode is still running and reuse the same interval
- add a configuration default for the preview throttle interval

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68fa5f417fd08325932ee56b62eb5da6