### PR TITLE
Fix dataclass compatibility in network helpers

### DIFF
--- a/core/gimbal_control.py
+++ b/core/gimbal_control.py
@@ -16,17 +16,23 @@ except ImportError:
     from serial.serialutil import SerialException
 
 from utils.helpers import euler_to_quat, wrap_angle_deg
+from network.bridge_tcp import parse_bridge_tcp_command
 from network.gimbal_icd import (
-    TYPE_GIMBAL_CTRL,
-    TYPE_POWER_CTRL,
     MC_HB_TYPE,
     GIMBAL_STATUS_FLAGS,
-    TCP_CMD_SET_TARGET,
-    TCP_CMD_SET_ZOOM,
-    TCP_CMD_GET_STATUS,
-    TCP_CMD_STATUS,
     PARAM_TABLE,
     PARAM_COUNT,
+    TCP_CMD_GET_STATUS,
+    TCP_CMD_SET_TARGET,
+    TCP_CMD_SET_ZOOM,
+)
+from network.gimbal_messages import (
+    StatusSnapshot,
+    build_gimbal_ctrl_packet,
+    build_power_ctrl_packet,
+    build_status_frame,
+    parse_set_target,
+    parse_set_zoom,
 )
 
 
@@ -613,19 +619,20 @@ class GimbalControl:
         return bytes(buf)
 
     def _process_tcp_command(self, payload: bytes, conn: socket.socket) -> None:
-        if len(payload) < 9:
+        command = parse_bridge_tcp_command(payload)
+        if command is None:
             self.log("[GIMBAL] TCP payload too short")
             return
-        ts_sec, ts_nsec, cmd_id = struct.unpack("<IIB", payload[:9])
-        body = payload[9:]
-        if cmd_id == TCP_CMD_SET_TARGET:
-            fmt = "<hh3d3f"
-            if len(body) != struct.calcsize(fmt):
-                self.log("[GIMBAL] TCP SET_TARGET malformed payload")
+
+        if command.cmd_id == TCP_CMD_SET_TARGET:
+            target = parse_set_target(command)
+            if target is None:
+                self.log("[GIMBAL] TCP SET_TARGET invalid payload")
                 return
-            sensor_type_raw, sensor_id_raw, px, py, pz, r_sim, p_sim, y_sim = struct.unpack(fmt, body)
-            sensor_type = self._sanitize_sensor_code(sensor_type_raw)
-            sensor_id = self._sanitize_sensor_code(sensor_id_raw)
+            sensor_type = self._sanitize_sensor_code(target.sensor_type)
+            sensor_id = self._sanitize_sensor_code(target.sensor_id)
+            px, py, pz = target.position_xyz
+            r_sim, p_sim, y_sim = target.sim_rpy
             r, p, y = self._sim_to_bridge_rpy(r_sim, p_sim, y_sim)
             with self._lock:
                 self.sensor_type = sensor_type
@@ -642,18 +649,18 @@ class GimbalControl:
                 f"xyz=({px:.2f},{py:.2f},{pz:.2f}) sim_rpy=({r_sim:.2f},{p_sim:.2f},{y_sim:.2f})"
             )
             self._send_status_message(conn)
-        elif cmd_id == TCP_CMD_SET_ZOOM:
-            if len(body) < 4:
-                self.log("[GIMBAL] TCP SET_ZOOM missing float")
+        elif command.cmd_id == TCP_CMD_SET_ZOOM:
+            zoom = parse_set_zoom(command)
+            if zoom is None:
+                self.log("[GIMBAL] TCP SET_ZOOM invalid payload")
                 return
-            (zoom_val,) = struct.unpack("<f", body[:4])
-            self._set_zoom_scale(float(zoom_val))
+            self._set_zoom_scale(zoom.zoom_scale)
             self.log(f"[GIMBAL] TCP zoom scale -> {self.zoom_scale:.2f}")
             self._send_status_message(conn)
-        elif cmd_id == TCP_CMD_GET_STATUS:
+        elif command.cmd_id == TCP_CMD_GET_STATUS:
             self._send_status_message(conn)
         else:
-            self.log(f"[GIMBAL] TCP unknown cmd: 0x{cmd_id:02X}")
+            self.log(f"[GIMBAL] TCP unknown cmd: 0x{command.cmd_id:02X}")
 
     def _send_status_message(self, conn: socket.socket) -> None:
         with self._lock:
@@ -666,28 +673,20 @@ class GimbalControl:
             max_rate = self.max_rate_dps
         r_cur_sim, p_cur_sim, y_cur_sim = self._bridge_to_sim_rpy(r_cur, p_cur, y_cur)
         r_tgt_sim, p_tgt_sim, y_tgt_sim = self._bridge_to_sim_rpy(r_tgt, p_tgt, y_tgt)
-        payload = struct.pack(
-            "<hh3d3f3ff",
-            sensor_type,
-            sensor_id,
-            px,
-            py,
-            pz,
-            r_cur_sim,
-            p_cur_sim,
-            y_cur_sim,
-            r_tgt_sim,
-            p_tgt_sim,
-            y_tgt_sim,
-            zoom,
-            max_rate,
+        snapshot = StatusSnapshot(
+            sensor_type=sensor_type,
+            sensor_id=sensor_id,
+            position_xyz=(px, py, pz),
+            sim_rpy_current=(r_cur_sim, p_cur_sim, y_cur_sim),
+            sim_rpy_target=(r_tgt_sim, p_tgt_sim, y_tgt_sim),
+            zoom_scale=zoom,
+            max_rate_dps=max_rate,
         )
         ts_sec = int(time.time())
         ts_nsec = time.time_ns() % 1_000_000_000
-        full = struct.pack("<IIB", ts_sec, ts_nsec, TCP_CMD_STATUS) + payload
-        header = struct.pack("<I", len(full))
+        frame = build_status_frame(snapshot, ts_sec=ts_sec, ts_nsec=ts_nsec)
         try:
-            conn.sendall(header + full)
+            conn.sendall(frame)
         except Exception as exc:
             self.log(f"[GIMBAL] TCP send status failed: {exc}")
 
@@ -904,31 +903,11 @@ class GimbalControl:
         sim_roll = self._normalize_angle(sim_roll)
         sim_pitch = self._normalize_angle(sim_pitch)
         sim_yaw = self._normalize_angle(sim_yaw)
-        qx, qy, qz, qw = euler_to_quat(sim_roll, sim_pitch, sim_yaw)
-        payload = struct.pack(
-            "<BB3d4f",
-            sensor_type & 0xFF,
-            sensor_id & 0xFF,
-            float(xyz[0]),
-            float(xyz[1]),
-            float(xyz[2]),
-            float(qx),
-            float(qy),
-            float(qz),
-            float(qw),
-        )
-        header = struct.pack("<BiIB", 1, TYPE_GIMBAL_CTRL, len(payload), 0)
-        return header + payload
+        quat = euler_to_quat(sim_roll, sim_pitch, sim_yaw)
+        return build_gimbal_ctrl_packet(sensor_type, sensor_id, (float(xyz[0]), float(xyz[1]), float(xyz[2])), quat)
 
     def _pack_power_ctrl(self, sensor_type: int, sensor_id: int, power_on: int) -> bytes:
-        payload = struct.pack(
-            "<BBB",
-            sensor_type & 0xFF,
-            sensor_id & 0xFF,
-            power_on & 0xFF,
-        )
-        header = struct.pack("<BiIB", 1, TYPE_POWER_CTRL, len(payload), 0)
-        return header + payload
+        return build_power_ctrl_packet(sensor_type, sensor_id, power_on)
 
     def _dump_packet_bytes(self, label: str, pkt: bytes) -> None:
         hex_str = " ".join(f"{b:02X}" for b in pkt)

--- a/network/__init__.py
+++ b/network/__init__.py
@@ -1,9 +1,11 @@
 """Network ICD definitions for Unified Bridge modules."""
 
-from . import image_stream_icd, gimbal_icd, gazebo_relay_icd
+from . import bridge_tcp, image_stream_icd, gimbal_icd, gazebo_relay_icd, gimbal_messages
 
 __all__ = [
+    "bridge_tcp",
     "image_stream_icd",
     "gimbal_icd",
     "gazebo_relay_icd",
+    "gimbal_messages",
 ]

--- a/network/bridge_tcp.py
+++ b/network/bridge_tcp.py
@@ -1,0 +1,84 @@
+"""Bridge-wide TCP framing helpers.
+
+The gimbal control server and the image stream bridge both use the same
+TCP transport layout: a 4-byte little-endian length prefix followed by a
+command envelope ``<IIB>`` (seconds, nanoseconds, command id) and the
+command-specific payload.  Centralising the helpers keeps the struct
+layouts documented in one place so that protocol tweaks only require a
+single update.
+"""
+
+from __future__ import annotations
+
+import struct
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+TCP_LENGTH_FMT = "<I"
+TCP_ENVELOPE_FMT = "<IIB"
+TCP_ENVELOPE_SIZE = struct.calcsize(TCP_ENVELOPE_FMT)
+
+
+@dataclass
+class BridgeTcpCommand:
+    """Parsed representation of a bridge TCP command frame."""
+
+    ts_sec: int
+    ts_nsec: int
+    cmd_id: int
+    body: bytes
+
+
+def parse_bridge_tcp_command(data: bytes) -> Optional[BridgeTcpCommand]:
+    """Return a :class:`BridgeTcpCommand` extracted from *data*.
+
+    ``None`` is returned when the payload is shorter than the envelope or
+    when unpacking fails.  The command body is returned as a ``bytes``
+    view without further interpretation so that the caller can keep the
+    higher level parsing in its own module.
+    """
+
+    if len(data) < TCP_ENVELOPE_SIZE:
+        return None
+    try:
+        ts_sec, ts_nsec, cmd_id = struct.unpack(TCP_ENVELOPE_FMT, data[:TCP_ENVELOPE_SIZE])
+    except struct.error:
+        return None
+    body = data[TCP_ENVELOPE_SIZE:]
+    return BridgeTcpCommand(ts_sec=int(ts_sec), ts_nsec=int(ts_nsec), cmd_id=int(cmd_id), body=bytes(body))
+
+
+def pack_bridge_tcp_frame(
+    cmd_id: int,
+    payload: bytes,
+    *,
+    ts_sec: Optional[int] = None,
+    ts_nsec: Optional[int] = None,
+) -> bytes:
+    """Pack a TCP frame for the bridge command transport.
+
+    ``ts_sec``/``ts_nsec`` default to ``time.time_ns()`` when omitted so
+    that callers that do not care about the exact timestamp can simply
+    provide the command id and payload.  The return value contains both
+    the 4-byte length prefix and the envelope+payload bytes so it is
+    ready to be written to a socket.
+    """
+
+    if ts_sec is None or ts_nsec is None:
+        now_ns = time.time_ns()
+        ts_sec = now_ns // 1_000_000_000
+        ts_nsec = now_ns % 1_000_000_000
+    envelope = struct.pack(TCP_ENVELOPE_FMT, int(ts_sec), int(ts_nsec), int(cmd_id)) + payload
+    header = struct.pack(TCP_LENGTH_FMT, len(envelope))
+    return header + envelope
+
+
+__all__ = [
+    "BridgeTcpCommand",
+    "TCP_LENGTH_FMT",
+    "TCP_ENVELOPE_FMT",
+    "TCP_ENVELOPE_SIZE",
+    "parse_bridge_tcp_command",
+    "pack_bridge_tcp_frame",
+]

--- a/network/gimbal_messages.py
+++ b/network/gimbal_messages.py
@@ -1,0 +1,145 @@
+"""Helpers for serialising and parsing gimbal control payloads."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from .bridge_tcp import BridgeTcpCommand, pack_bridge_tcp_frame
+from .gimbal_icd import (
+    TYPE_GIMBAL_CTRL,
+    TYPE_POWER_CTRL,
+    TCP_CMD_SET_TARGET,
+    TCP_CMD_SET_ZOOM,
+    TCP_CMD_STATUS,
+)
+
+_GIMBAL_CTRL_HEADER_FMT = "<BiIB"
+_GIMBAL_CTRL_PAYLOAD_FMT = "<BB3d4f"
+_POWER_CTRL_HEADER_FMT = "<BiIB"
+_POWER_CTRL_PAYLOAD_FMT = "<BBB"
+_STATUS_PAYLOAD_FMT = "<hh3d3f3ff"
+_SET_TARGET_FMT = "<hh3d3f"
+
+
+@dataclass
+class SetTargetPayload:
+    sensor_type: int
+    sensor_id: int
+    position_xyz: Tuple[float, float, float]
+    sim_rpy: Tuple[float, float, float]
+
+
+@dataclass
+class SetZoomPayload:
+    zoom_scale: float
+
+
+@dataclass
+class StatusSnapshot:
+    sensor_type: int
+    sensor_id: int
+    position_xyz: Tuple[float, float, float]
+    sim_rpy_current: Tuple[float, float, float]
+    sim_rpy_target: Tuple[float, float, float]
+    zoom_scale: float
+    max_rate_dps: float
+
+
+def build_gimbal_ctrl_packet(
+    sensor_type: int,
+    sensor_id: int,
+    position_xyz: Tuple[float, float, float],
+    quat_xyzw: Tuple[float, float, float, float],
+) -> bytes:
+    """Pack the UDP control packet consumed by the ImageGenerator.
+
+    The quaternion must be supplied in ``(x, y, z, w)`` order to match the
+    :func:`utils.helpers.euler_to_quat` helper used by the bridge.
+    """
+
+    payload = struct.pack(
+        _GIMBAL_CTRL_PAYLOAD_FMT,
+        sensor_type & 0xFF,
+        sensor_id & 0xFF,
+        float(position_xyz[0]),
+        float(position_xyz[1]),
+        float(position_xyz[2]),
+        float(quat_xyzw[0]),
+        float(quat_xyzw[1]),
+        float(quat_xyzw[2]),
+        float(quat_xyzw[3]),
+    )
+    header = struct.pack(_GIMBAL_CTRL_HEADER_FMT, 1, TYPE_GIMBAL_CTRL, len(payload), 0)
+    return header + payload
+
+
+def build_power_ctrl_packet(sensor_type: int, sensor_id: int, power_on: int) -> bytes:
+    payload = struct.pack(
+        _POWER_CTRL_PAYLOAD_FMT,
+        sensor_type & 0xFF,
+        sensor_id & 0xFF,
+        power_on & 0xFF,
+    )
+    header = struct.pack(_POWER_CTRL_HEADER_FMT, 1, TYPE_POWER_CTRL, len(payload), 0)
+    return header + payload
+
+
+def build_status_frame(snapshot: StatusSnapshot, *, ts_sec: int, ts_nsec: int) -> bytes:
+    payload = struct.pack(
+        _STATUS_PAYLOAD_FMT,
+        int(snapshot.sensor_type),
+        int(snapshot.sensor_id),
+        float(snapshot.position_xyz[0]),
+        float(snapshot.position_xyz[1]),
+        float(snapshot.position_xyz[2]),
+        float(snapshot.sim_rpy_current[0]),
+        float(snapshot.sim_rpy_current[1]),
+        float(snapshot.sim_rpy_current[2]),
+        float(snapshot.sim_rpy_target[0]),
+        float(snapshot.sim_rpy_target[1]),
+        float(snapshot.sim_rpy_target[2]),
+        float(snapshot.zoom_scale),
+        float(snapshot.max_rate_dps),
+    )
+    return pack_bridge_tcp_frame(TCP_CMD_STATUS, payload, ts_sec=ts_sec, ts_nsec=ts_nsec)
+
+
+def parse_set_target(command: BridgeTcpCommand) -> Optional[SetTargetPayload]:
+    if command.cmd_id != TCP_CMD_SET_TARGET or len(command.body) < struct.calcsize(_SET_TARGET_FMT):
+        return None
+    try:
+        sensor_type, sensor_id, px, py, pz, r_sim, p_sim, y_sim = struct.unpack(
+            _SET_TARGET_FMT, command.body[: struct.calcsize(_SET_TARGET_FMT)]
+        )
+    except struct.error:
+        return None
+    return SetTargetPayload(
+        sensor_type=int(sensor_type),
+        sensor_id=int(sensor_id),
+        position_xyz=(float(px), float(py), float(pz)),
+        sim_rpy=(float(r_sim), float(p_sim), float(y_sim)),
+    )
+
+
+def parse_set_zoom(command: BridgeTcpCommand) -> Optional[SetZoomPayload]:
+    if command.cmd_id != TCP_CMD_SET_ZOOM or len(command.body) < 4:
+        return None
+    try:
+        (zoom_val,) = struct.unpack("<f", command.body[:4])
+    except struct.error:
+        return None
+    return SetZoomPayload(zoom_scale=float(zoom_val))
+
+
+__all__ = [
+    "SetTargetPayload",
+    "SetZoomPayload",
+    "StatusSnapshot",
+    "build_gimbal_ctrl_packet",
+    "build_power_ctrl_packet",
+    "build_status_frame",
+    "parse_set_target",
+    "parse_set_zoom",
+]


### PR DESCRIPTION
## Summary
- remove usage of the dataclass slots option in bridge TCP helpers to support older Python versions
- drop dataclass slots from gimbal message payloads for broader runtime compatibility

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68fb39e4c2ec832593931f44c749b0c7