### PR TITLE
Add Tk heartbeat watchdog to restart bridge on UI stalls

### DIFF
--- a/utils/settings.py
+++ b/utils/settings.py
@@ -326,6 +326,22 @@ class AppConfig:
         if path:
             ensure_dir(os.path.dirname(path))
 
+        # UI / Heartbeat 기본값
+        ui_cfg = self._extras.setdefault("ui", {})
+        if not isinstance(ui_cfg, dict):
+            ui_cfg = {}
+            self._extras["ui"] = ui_cfg
+        heartbeat_cfg = ui_cfg.setdefault("heartbeat", {})
+        if not isinstance(heartbeat_cfg, dict):
+            heartbeat_cfg = {}
+            ui_cfg["heartbeat"] = heartbeat_cfg
+        heartbeat_cfg.setdefault("enabled", True)
+        heartbeat_cfg.setdefault("interval_sec", 1.0)
+        heartbeat_cfg.setdefault("timeout_sec", 5.0)
+        heartbeat_cfg.setdefault("recovery_cooldown_sec", 30.0)
+        heartbeat_cfg.setdefault("restart_delay_sec", 1.0)
+        heartbeat_cfg.setdefault("restart_bridge", True)
+
     # ---------- 편의 메서드 ----------
 
     def get_save_dir(self) -> str:


### PR DESCRIPTION
## Summary
- add a Tk heartbeat watchdog that restarts the image bridge when the GUI stops responding
- expose heartbeat defaults in the saved configuration so operators can tune the watchdog timing

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68fb50f7da308325a1e997a6f57c1fa5