### PR TITLE
Correct TCP gimbal roll/pitch/yaw ordering

### DIFF
--- a/core/gimbal_control.py
+++ b/core/gimbal_control.py
@@ -632,8 +632,10 @@ class GimbalControl:
             sensor_type = self._sanitize_sensor_code(target.sensor_type)
             sensor_id = self._sanitize_sensor_code(target.sensor_id)
             px, py, pz = target.position_xyz
-            r_sim, p_sim, y_sim = target.sim_rpy
-            r, p, y = self._sim_to_bridge_rpy(r_sim, p_sim, y_sim)
+            # TCP controllers send roll/pitch/yaw in the same order used by the UI.
+            # Store the values directly so the downstream quaternion packing applies
+            # the identical Unreal mapping as manual inputs.
+            r, p, y = (float(target.sim_rpy[0]), float(target.sim_rpy[1]), float(target.sim_rpy[2]))
             with self._lock:
                 self.sensor_type = sensor_type
                 self.sensor_id = sensor_id
@@ -646,7 +648,7 @@ class GimbalControl:
                 self._last_sent_snapshot = None
             self.log(
                 f"[GIMBAL] TCP target -> sensor={sensor_type}/{sensor_id} "
-                f"xyz=({px:.2f},{py:.2f},{pz:.2f}) sim_rpy=({r_sim:.2f},{p_sim:.2f},{y_sim:.2f})"
+                f"xyz=({px:.2f},{py:.2f},{pz:.2f}) rpy=({r:.2f},{p:.2f},{y:.2f})"
             )
             self._send_status_message(conn)
         elif command.cmd_id == TCP_CMD_SET_ZOOM:

--- a/network/gimbal_messages.py
+++ b/network/gimbal_messages.py
@@ -25,6 +25,11 @@ _SET_TARGET_FMT = "<hh3d3f"
 
 @dataclass
 class SetTargetPayload:
+    """Decoded payload for :data:`TCP_CMD_SET_TARGET`.
+
+    The ``sim_rpy`` tuple carries roll/pitch/yaw in the bridge/UI order so that
+    TCP controllers can share the same orientation convention as the manual UI.
+    """
     sensor_type: int
     sensor_id: int
     position_xyz: Tuple[float, float, float]

--- a/ui/gimbal_window.py
+++ b/ui/gimbal_window.py
@@ -383,12 +383,12 @@ class GimbalControlsDialog(QtWidgets.QDialog):
         layout.addWidget(self.status_label)
 
         btn_box = QtWidgets.QDialogButtonBox()
-        btn_box.addButton("Save", QtWidgets.QDialogButtonBox.ActionRole)
+        save_button = btn_box.addButton("Save", QtWidgets.QDialogButtonBox.ActionRole)
         btn_box.addButton(QtWidgets.QDialogButtonBox.Ok)
         btn_box.addButton(QtWidgets.QDialogButtonBox.Cancel)
         layout.addWidget(btn_box)
 
-        btn_box.button(QtWidgets.QDialogButtonBox.ActionRole).clicked.connect(self.on_save)
+        save_button.clicked.connect(self.on_save)
         btn_box.accepted.connect(self.on_apply_close)
         btn_box.rejected.connect(self.reject)
 


### PR DESCRIPTION
## Summary
- align TCP SET_TARGET roll/pitch/yaw handling with the UI flow so quaternion packing uses the same Unreal mapping
- document the expected orientation order in the gimbal TCP message helper

## Testing
- python -m compileall core/gimbal_control.py network/gimbal_messages.py

------
https://chatgpt.com/codex/tasks/task_e_68fdc33da0588325984e59bf33bc9690