### PR TITLE
Guard PySide6 UI from background thread deadlocks

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -76,6 +76,8 @@ class PreviewLabel(QtWidgets.QLabel):
 class MainWindow(QtWidgets.QMainWindow):
     """PySide6 port of the Unified Bridge main window."""
 
+    zoom_changed = QtCore.Signal(float)
+
     def __init__(
         self,
         cfg: Dict[str, Any],
@@ -130,6 +132,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._build_preview_area()
         self._build_log_area()
 
+        self.zoom_changed.connect(self._apply_zoom_value)
         self._init_zoom_subscription()
         self._install_preview_bridge()
         self._refresh_status_labels()
@@ -307,10 +310,14 @@ class MainWindow(QtWidgets.QMainWindow):
             return
 
         def _on_zoom(value: float) -> None:
-            self._current_zoom_value = value
-            self.lbl_zoom.setText(f"Zoom: {value:.2f}x")
+            self.zoom_changed.emit(value)
 
         self._zoom_unsubscribe = self.zoom_state.subscribe(_on_zoom)
+
+    @QtCore.Slot(float)
+    def _apply_zoom_value(self, value: float) -> None:
+        self._current_zoom_value = value
+        self.lbl_zoom.setText(f"Zoom: {value:.2f}x")
 
     def _install_preview_bridge(self) -> None:
         try:

--- a/ui/relay_window.py
+++ b/ui/relay_window.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+import threading
+from typing import Any, Dict, Optional
 
 from PySide6 import QtCore, QtGui, QtWidgets
 from serial.tools import list_ports
@@ -24,6 +25,7 @@ class RelaySettingsDialog(QtWidgets.QDialog):
 
         rconf = cfg.get("relay", {})
         self.fields: Dict[str, QtWidgets.QWidget] = {}
+        self._stop_in_progress = False
 
         self._build_layout(rconf)
         self._status_timer = QtCore.QTimer(self)
@@ -381,11 +383,38 @@ class RelaySettingsDialog(QtWidgets.QDialog):
             QtWidgets.QMessageBox.critical(self, "Error", f"Start failed:\n{exc}")
 
     def on_stop(self) -> None:
-        try:
-            self.relay.stop()
+        if self._stop_in_progress:
+            return
+        self._stop_in_progress = True
+        self.btn_stop.setEnabled(False)
+        self.btn_start.setEnabled(False)
+
+        def worker() -> None:
+            error: Optional[Exception] = None
+            try:
+                self.relay.stop()
+            except Exception as exc:
+                error = exc
+            finally:
+                QtCore.QMetaObject.invokeMethod(
+                    self,
+                    "_on_stop_finished",
+                    QtCore.Qt.QueuedConnection,
+                    QtCore.Q_ARG(object, error),
+                )
+
+        threading.Thread(target=worker, name="RelayStop", daemon=True).start()
+
+    @QtCore.Slot(object)
+    def _on_stop_finished(self, error: Optional[Exception]) -> None:
+        self._stop_in_progress = False
+        self.btn_stop.setEnabled(True)
+        self.btn_start.setEnabled(True)
+        if error is not None:
+            QtWidgets.QMessageBox.critical(self, "Error", f"Stop failed:\n{error}")
+        else:
             QtWidgets.QMessageBox.information(self, "Relay", "Relay stopped.")
-        except Exception as exc:
-            QtWidgets.QMessageBox.critical(self, "Error", f"Stop failed:\n{exc}")
+        self._refresh_status()
 
     def on_save(self) -> None:
         try:


### PR DESCRIPTION
## Summary
- marshal zoom updates through a Qt signal so background gimbal threads cannot touch widgets directly
- stop the relay and rover services via worker threads and restore the UI once the shutdown completes

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68fdd825c5b4832596e8b651f0b66060