### PR TITLE
Improve gimbal presets and relay logging status

### DIFF
--- a/core/udp_relay.py
+++ b/core/udp_relay.py
@@ -769,6 +769,22 @@ class UdpRelay:
             })
         return status
 
+    def get_logging_status(self) -> Dict[str, Any]:
+        """Expose a lightweight snapshot for UI logging indicators."""
+
+        with self._gazebo_log_lock:
+            active = bool(self.running and self._gazebo_log_file is not None)
+            status = {
+                "enable_gazebo_logging": self._gazebo_logging_enabled,
+                "gazebo_logging_active": active,
+                "gazebo_logged_count": self._gazebo_log_count,
+                "gazebo_log_path": self.gazebo_log_path,
+                "gazebo_log_last_write_ts": self._gazebo_log_last_ts if self._gazebo_log_last_ts else None,
+                "gazebo_log_block_reason": self._gazebo_log_block_reason,
+                "gazebo_log_error": self._gazebo_log_error,
+            }
+        return status
+
     # ------------- 내부 유틸 -------------
     def _open_serial_shared(self, force: bool = False) -> None:
         port = str(self.s.get("serial_port", "")).strip()

--- a/ui/relay_window.py
+++ b/ui/relay_window.py
@@ -238,8 +238,10 @@ class RelaySettingsDialog(QtWidgets.QDialog):
         # Status + Buttons
         self.status_label = QtWidgets.QLabel("Status: -")
         self.detail_label = QtWidgets.QLabel("-")
+        self.logging_label = QtWidgets.QLabel("Logging: Unknown")
         layout.addWidget(self.status_label)
         layout.addWidget(self.detail_label)
+        layout.addWidget(self.logging_label)
 
         btn_box = QtWidgets.QDialogButtonBox()
         self.btn_start = QtWidgets.QPushButton("Start Relay")
@@ -333,6 +335,23 @@ class RelaySettingsDialog(QtWidgets.QDialog):
             if serial:
                 detail.append(f"Serial: {serial}")
         self.detail_label.setText(" | ".join(detail) or "-")
+
+        try:
+            log_status = self.relay.get_logging_status() if hasattr(self.relay, "get_logging_status") else {}
+        except Exception:
+            log_status = {}
+        if isinstance(log_status, dict):
+            enabled = bool(log_status.get("enable_gazebo_logging", True))
+            active = bool(log_status.get("gazebo_logging_active"))
+            if not enabled:
+                text = "Logging: Disabled"
+            else:
+                text = "Logging: ON" if active else "Logging: OFF"
+            if log_status.get("gazebo_log_block_reason"):
+                text = f"{text} (Blocked)"
+        else:
+            text = "Logging: Unknown"
+        self.logging_label.setText(text)
 
     # ------------------------------------------------------------------
     def on_browse_log(self) -> None:


### PR DESCRIPTION
## Summary
- ensure gimbal presets persist cleanly to disk and expose a power command button with packet preview
- expose a UDP relay logging snapshot and surface it in the settings dialog
- add helpers in gimbal control to build/send power packets for UI consumption

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68fde53149c88325a38c77eecc431ddc