### PR TITLE
Normalize legacy RPY mapping for gimbal control inputs

### DIFF
--- a/core/gimbal_control.py
+++ b/core/gimbal_control.py
@@ -474,6 +474,34 @@ class GimbalControl:
             )
         return orientation
 
+    def set_target_pose_from_rpy(
+        self,
+        x: float,
+        y: float,
+        z: float,
+        roll_deg: float,
+        pitch_deg: float,
+        yaw_deg: float,
+        *,
+        persist: bool = False,
+        log: bool = True,
+    ) -> _SimOrientation:
+        """Apply a target pose using legacy roll/pitch/yaw ordering."""
+
+        sim_pitch, sim_yaw, sim_roll = self._bridge_to_sim_rpy(
+            roll_deg, pitch_deg, yaw_deg
+        )
+        return self.set_target_pose(
+            x,
+            y,
+            z,
+            sim_pitch,
+            sim_yaw,
+            sim_roll,
+            persist=persist,
+            log=log,
+        )
+
     def set_max_rate(self, rate_dps: float) -> None:
         with self._lock:
             self.max_rate_dps = float(rate_dps)
@@ -862,26 +890,23 @@ class GimbalControl:
                 float(target.position_xyz[1]),
                 float(target.position_xyz[2]),
             )
-            sim_pitch, sim_yaw, sim_roll = (
-                float(target.sim_rpy[0]),
-                float(target.sim_rpy[1]),
-                float(target.sim_rpy[2]),
-            )
+            legacy_roll, legacy_pitch, legacy_yaw = target.legacy_rpy
             with self._lock:
                 self.sensor_type = sensor_type
                 self.sensor_id = sensor_id
                 self.s["sensor_type"] = self.sensor_type
                 self.s["sensor_id"] = self.sensor_id
-            orientation = self.set_target_pose(
+            orientation = self.set_target_pose_from_rpy(
                 px,
                 py,
                 pz,
-                sim_pitch,
-                sim_yaw,
-                sim_roll,
+                legacy_roll,
+                legacy_pitch,
+                legacy_yaw,
                 persist=True,
                 log=False,
             )
+            sim_pitch, sim_yaw, sim_roll = orientation.sim_rpy
             self.log(
                 f"[GIMBAL] TCP target -> sensor={sensor_type}/{sensor_id} "
                 f"xyz=({px:.2f},{py:.2f},{pz:.2f}) sim_rpy(P,Y,R)=({sim_pitch:.2f},{sim_yaw:.2f},{sim_roll:.2f}) "
@@ -1027,7 +1052,15 @@ class GimbalControl:
                     avx = getattr(m, "angular_velocity_x", float("nan"))
                     # mode b: q 유효 → 목표 각도 설정
                     if not any(math.isnan(v) for v in q):
-                        sim_pitch, sim_yaw, sim_roll = _quat_to_frotator_deg(q[0], q[1], q[2], q[3])
+                        sim_pitch, sim_yaw, sim_roll = _quat_to_frotator_deg(
+                            q[0], q[1], q[2], q[3]
+                        )
+                        legacy_roll, legacy_pitch, legacy_yaw = self._sim_to_bridge_rpy(
+                            sim_pitch, sim_yaw, sim_roll
+                        )
+                        sim_pitch, sim_yaw, sim_roll = self._bridge_to_sim_rpy(
+                            legacy_roll, legacy_pitch, legacy_yaw
+                        )
                         orientation = self._orientation_pipeline.build_from_sim(
                             sim_pitch, sim_yaw, sim_roll
                         )

--- a/ui/gimbal_window.py
+++ b/ui/gimbal_window.py
@@ -509,20 +509,30 @@ class GimbalControlsDialog(QtWidgets.QDialog):
                 roll = values.get("init_roll_deg", 0.0)
                 pitch = values.get("init_pitch_deg", 0.0)
                 yaw = values.get("init_yaw_deg", 0.0)
-                if hasattr(self.gimbal, "_bridge_to_sim_rpy"):
-                    sim_pitch, sim_yaw, sim_roll = self.gimbal._bridge_to_sim_rpy(
-                        roll, pitch, yaw
+                if hasattr(self.gimbal, "set_target_pose_from_rpy"):
+                    self.gimbal.set_target_pose_from_rpy(
+                        values.get("pos_x", 0.0),
+                        values.get("pos_y", 0.0),
+                        values.get("pos_z", 0.0),
+                        roll,
+                        pitch,
+                        yaw,
                     )
                 else:
-                    sim_pitch, sim_yaw, sim_roll = float(pitch), float(yaw), float(roll)
-                self.gimbal.set_target_pose(
-                    values.get("pos_x", 0.0),
-                    values.get("pos_y", 0.0),
-                    values.get("pos_z", 0.0),
-                    sim_pitch,
-                    sim_yaw,
-                    sim_roll,
-                )
+                    if hasattr(self.gimbal, "_bridge_to_sim_rpy"):
+                        sim_pitch, sim_yaw, sim_roll = self.gimbal._bridge_to_sim_rpy(
+                            roll, pitch, yaw
+                        )
+                    else:
+                        sim_pitch, sim_yaw, sim_roll = float(pitch), float(yaw), float(roll)
+                    self.gimbal.set_target_pose(
+                        values.get("pos_x", 0.0),
+                        values.get("pos_y", 0.0),
+                        values.get("pos_z", 0.0),
+                        sim_pitch,
+                        sim_yaw,
+                        sim_roll,
+                    )
             if hasattr(self.gimbal, "set_max_rate"):
                 self.gimbal.set_max_rate(values.get("max_rate_dps", 60.0))
             if hasattr(self.gimbal, "set_power"):


### PR DESCRIPTION
## Summary
- add a `set_target_pose_from_rpy` helper so gimbal control maps legacy roll/pitch/yaw immediately
- expose legacy angle triples in TCP SetTarget payloads and reuse the helper for TCP and MAVLink handling
- route the UI gimbal dialog through the helper instead of duplicating conversion logic

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_6900137a7eb883259594c320481690d2