### PR TITLE
Correct RPY-to-PYR remapping before UDP output

### DIFF
--- a/core/image_stream_bridge.py
+++ b/core/image_stream_bridge.py
@@ -658,9 +658,9 @@ class ImageStreamBridge:
     ) -> tuple[float, float, float]:
         """Return simulator-ordered angles from legacy roll/pitch/yaw input."""
 
-        pitch = float(pitch_deg)
-        yaw = float(yaw_deg)
-        roll = float(roll_deg)
+        pitch = float(roll_deg)
+        yaw = float(pitch_deg)
+        roll = float(yaw_deg)
         return pitch, yaw, roll
 
     # --------------- UDP Receiver (New ICD) ---------------

--- a/network/gimbal_messages.py
+++ b/network/gimbal_messages.py
@@ -24,9 +24,9 @@ _SET_TARGET_FMT = "<hh3d3f"
 
 
 def _legacy_rpy_to_sim(roll: float, pitch: float, yaw: float) -> Tuple[float, float, float]:
-    """Map legacy roll/pitch/yaw ordering into (Pitch, Yaw, Roll)."""
+    """Map legacy roll/pitch/yaw so ``Pitch←Roll, Yaw←Pitch, Roll←Yaw``."""
 
-    return float(pitch), float(yaw), float(roll)
+    return float(roll), float(pitch), float(yaw)
 
 
 @dataclass
@@ -34,14 +34,16 @@ class SetTargetPayload:
     """Decoded payload for :data:`TCP_CMD_SET_TARGET`.
 
     The underlying TCP command still transmits angles in the legacy
-    roll-pitch-yaw order for backward compatibility.  The ``sim_rpy`` tuple
-    normalizes those angles into the Unreal ``FRotator`` ordering of
-    (Pitch, Yaw, Roll) so downstream code can reason about the simulator
-    convention without worrying about the on-wire layout.
+    roll-pitch-yaw order for backward compatibility.  The ``legacy_rpy``
+    attribute preserves those raw angles, while ``sim_rpy`` normalizes them
+    into the Unreal ``FRotator`` ordering of (Pitch, Yaw, Roll) so downstream
+    code can reason about the simulator convention without worrying about the
+    on-wire layout.
     """
     sensor_type: int
     sensor_id: int
     position_xyz: Tuple[float, float, float]
+    legacy_rpy: Tuple[float, float, float]
     sim_rpy: Tuple[float, float, float]
 
 
@@ -129,11 +131,13 @@ def parse_set_target(command: BridgeTcpCommand) -> Optional[SetTargetPayload]:
         )
     except struct.error:
         return None
-    sim_pitch, sim_yaw, sim_roll = _legacy_rpy_to_sim(roll_sim, pitch_sim, yaw_sim)
+    legacy_rpy = (float(roll_sim), float(pitch_sim), float(yaw_sim))
+    sim_pitch, sim_yaw, sim_roll = _legacy_rpy_to_sim(*legacy_rpy)
     return SetTargetPayload(
         sensor_type=int(sensor_type),
         sensor_id=int(sensor_id),
         position_xyz=(float(px), float(py), float(pz)),
+        legacy_rpy=legacy_rpy,
         sim_rpy=(sim_pitch, sim_yaw, sim_roll),
     )
 

--- a/ui/gimbal_window.py
+++ b/ui/gimbal_window.py
@@ -509,20 +509,30 @@ class GimbalControlsDialog(QtWidgets.QDialog):
                 roll = values.get("init_roll_deg", 0.0)
                 pitch = values.get("init_pitch_deg", 0.0)
                 yaw = values.get("init_yaw_deg", 0.0)
-                if hasattr(self.gimbal, "_bridge_to_sim_rpy"):
-                    sim_pitch, sim_yaw, sim_roll = self.gimbal._bridge_to_sim_rpy(
-                        roll, pitch, yaw
+                if hasattr(self.gimbal, "set_target_pose_from_rpy"):
+                    self.gimbal.set_target_pose_from_rpy(
+                        values.get("pos_x", 0.0),
+                        values.get("pos_y", 0.0),
+                        values.get("pos_z", 0.0),
+                        roll,
+                        pitch,
+                        yaw,
                     )
                 else:
-                    sim_pitch, sim_yaw, sim_roll = float(pitch), float(yaw), float(roll)
-                self.gimbal.set_target_pose(
-                    values.get("pos_x", 0.0),
-                    values.get("pos_y", 0.0),
-                    values.get("pos_z", 0.0),
-                    sim_pitch,
-                    sim_yaw,
-                    sim_roll,
-                )
+                    if hasattr(self.gimbal, "_bridge_to_sim_rpy"):
+                        sim_pitch, sim_yaw, sim_roll = self.gimbal._bridge_to_sim_rpy(
+                            roll, pitch, yaw
+                        )
+                    else:
+                        sim_pitch, sim_yaw, sim_roll = float(pitch), float(yaw), float(roll)
+                    self.gimbal.set_target_pose(
+                        values.get("pos_x", 0.0),
+                        values.get("pos_y", 0.0),
+                        values.get("pos_z", 0.0),
+                        sim_pitch,
+                        sim_yaw,
+                        sim_roll,
+                    )
             if hasattr(self.gimbal, "set_max_rate"):
                 self.gimbal.set_max_rate(values.get("max_rate_dps", 60.0))
             if hasattr(self.gimbal, "set_power"):


### PR DESCRIPTION
## Summary
- remap legacy roll/pitch/yaw triples so downstream logic treats them as Pitch←Roll, Yaw←Pitch, Roll←Yaw
- mirror the updated conversion in the TCP SetTarget decoder and image bridge Set_Gimbal handler to keep inputs consistent

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_6900137a7eb883259594c320481690d2