### PR TITLE
Restore legacy RPY-to-simulator ordering

### DIFF
--- a/core/gimbal_control.py
+++ b/core/gimbal_control.py
@@ -96,6 +96,8 @@ class _SimOrientationPipeline:
         channel_key = channel or self._DEFAULT_CHANNEL
         with self._lock:
             prev = self._last_quat.get(channel_key)
+            if prev is None and reference_quat is not None:
+                prev = reference_quat
             if prev is not None:
                 dot = sum(a * b for a, b in zip(quat, prev))
                 if dot < 0.0:
@@ -109,7 +111,7 @@ class _SimOrientationPipeline:
             bridge_roll=bridge_roll,
             bridge_pitch=bridge_pitch,
             bridge_yaw=bridge_yaw,
-            quat_xyzw=quat_tuple,
+            quat_xyzw=quat,
         )
 
 


### PR DESCRIPTION
## Summary
- correct the legacy roll/pitch/yaw to simulator Pitch/Yaw/Roll remapping inside the gimbal controller and TCP decoder
- align the image bridge conversion helper with the same ordering so quaternion canonicalization operates on correctly mapped inputs
- restore shortest-arc quaternion continuity in the simulator orientation pipeline by reusing cached or reference orientations before emitting a pose

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_69002ddaaafc8325b6349f1dd9565f76