### PR TITLE
Fix gimbal orientation pipeline regression

### DIFF
--- a/core/gimbal_control.py
+++ b/core/gimbal_control.py
@@ -73,55 +73,11 @@ class _SimOrientationPipeline:
     def reset(self, channel: Optional[str] = None) -> None:
         """Clear cached quaternions used for continuity enforcement."""
 
-        return None
-
-    @staticmethod
-    def _coerce_quaternion(
-        values: Any,
-    ) -> Optional[Tuple[float, float, float, float]]:
-        if values is None:
-            return None
-        try:
-            candidate = tuple(float(v) for v in values)
-        except (TypeError, ValueError):
-            return None
-        if len(candidate) != 4:
-            return None
-        if any(not math.isfinite(v) for v in candidate):
-            return None
-        return candidate
-
-    @staticmethod
-    def _normalize_quaternion(
-        quat: Optional[Tuple[float, float, float, float]]
-    ) -> Optional[Tuple[float, float, float, float]]:
-        if quat is None:
-            return None
-        norm = math.sqrt(sum(a * a for a in quat))
-        if not norm or not math.isfinite(norm):
-            return None
-        return tuple(a / norm for a in quat)
-
-    @staticmethod
-    def _dot(
-        a: Tuple[float, float, float, float],
-        b: Tuple[float, float, float, float],
-    ) -> float:
-        return sum(x * y for x, y in zip(a, b))
-
-    def _align_quaternion(
-        self,
-        quat: Tuple[float, float, float, float],
-        reference: Optional[Tuple[float, float, float, float]],
-        prev: Optional[Tuple[float, float, float, float]],
-    ) -> Tuple[float, float, float, float]:
-        candidate = quat
-        if reference is not None and self._dot(candidate, reference) < 0.0:
-            candidate = tuple(-v for v in candidate)
-        if prev is not None and self._dot(candidate, prev) < 0.0:
-            candidate = tuple(-v for v in candidate)
-        normalized = self._normalize_quaternion(candidate)
-        return normalized or candidate
+        with self._lock:
+            if channel is None:
+                self._last_quat.clear()
+            else:
+                self._last_quat.pop(channel, None)
 
     @staticmethod
     def _coerce_quaternion(
@@ -189,7 +145,7 @@ class _SimOrientationPipeline:
         bridge_pitch = pitch
         bridge_yaw = yaw
 
-        quat = tuple(
+        quat_raw = tuple(
             float(a) for a in euler_to_quat(bridge_roll, bridge_pitch, bridge_yaw)
         )
 


### PR DESCRIPTION
## Summary
- clear cached quaternions properly when the orientation pipeline is reset
- remove duplicated quaternion helper definitions and fix use of the raw Euler quaternion in gimbal conversions

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_690045af21fc83259d62eb3598df0bfd