### PR TITLE
Remap UI/TCP/MAV Euler inputs to simulator order

### DIFF
--- a/network/gimbal_messages.py
+++ b/network/gimbal_messages.py
@@ -14,6 +14,7 @@ from .gimbal_icd import (
     TCP_CMD_SET_ZOOM,
     TCP_CMD_STATUS,
 )
+from utils.helpers import remap_input_rpy
 
 _GIMBAL_CTRL_HEADER_FMT = "<BiIB"
 _GIMBAL_CTRL_PAYLOAD_FMT = "<BB3d4f"
@@ -123,9 +124,11 @@ def parse_set_target(command: BridgeTcpCommand) -> Optional[SetTargetPayload]:
         )
     except struct.error:
         return None
-    sim_pitch = float(pitch_sim)
-    sim_yaw = float(yaw_sim)
-    sim_roll = float(roll_sim)
+    sim_pitch, sim_yaw, sim_roll = remap_input_rpy(
+        float(roll_sim),
+        float(pitch_sim),
+        float(yaw_sim),
+    )
     return SetTargetPayload(
         sensor_type=int(sensor_type),
         sensor_id=int(sensor_id),

--- a/ui/gimbal_window.py
+++ b/ui/gimbal_window.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from PySide6 import QtWidgets
 from serial.tools import list_ports
 
+from utils.helpers import remap_input_rpy
 from utils.settings import AppConfig, ConfigManager
 
 
@@ -507,13 +508,18 @@ class GimbalControlsDialog(QtWidgets.QDialog):
             if hasattr(self.gimbal, "update_settings"):
                 self.gimbal.update_settings(values)
             if hasattr(self.gimbal, "set_target_pose"):
+                sim_pitch, sim_yaw, sim_roll = remap_input_rpy(
+                    values.get("init_roll_deg", 0.0),
+                    values.get("init_pitch_deg", 0.0),
+                    values.get("init_yaw_deg", 0.0),
+                )
                 self.gimbal.set_target_pose(
                     values.get("pos_x", 0.0),
                     values.get("pos_y", 0.0),
                     values.get("pos_z", 0.0),
-                    values.get("init_pitch_deg", 0.0),
-                    values.get("init_yaw_deg", 0.0),
-                    values.get("init_roll_deg", 0.0),
+                    sim_pitch,
+                    sim_yaw,
+                    sim_roll,
                 )
             if hasattr(self.gimbal, "set_max_rate"):
                 self.gimbal.set_max_rate(values.get("max_rate_dps", 60.0))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -33,11 +33,18 @@ try:
         get_logger,
         euler_to_quat,
         wrap_angle_deg,
+        remap_input_rpy,
         clamp,
         rate_limit,
     )
 except Exception:  # pragma: no cover
-    has_display = get_logger = euler_to_quat = wrap_angle_deg = clamp = rate_limit = None  # type: ignore
+    has_display = (
+        get_logger
+    ) = (
+        euler_to_quat
+    ) = (
+        wrap_angle_deg
+    ) = remap_input_rpy = clamp = rate_limit = None  # type: ignore
 
 
 __all__ = [
@@ -53,6 +60,7 @@ __all__ = [
     "get_logger",
     "euler_to_quat",
     "wrap_angle_deg",
+    "remap_input_rpy",
     "clamp",
     "rate_limit",
 ]

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -180,6 +180,21 @@ def wrap_angle_deg(angle: float) -> float:
     return wrapped
 
 
+def remap_input_rpy(
+    roll_deg: float, pitch_deg: float, yaw_deg: float
+) -> Tuple[float, float, float]:
+    """Remap UI/TCP/MAV roll/pitch/yaw inputs into simulator order."""
+
+    # 각 채널(UI, TCP/IP, MAVLink)에서 전달되는 오일러각은 레이블과 실제 축이
+    # 순환(rotated) 관계를 가진다. 입력 ``roll`` 값은 시뮬레이터의 Pitch, 입력
+    # ``pitch`` 값은 시뮬레이터의 Yaw, 입력 ``yaw`` 값은 시뮬레이터의 Roll에
+    # 대응하므로 이를 (Pitch, Yaw, Roll) 순서로 재배열한다.
+    sim_pitch = float(roll_deg)
+    sim_yaw = float(pitch_deg)
+    sim_roll = float(yaw_deg)
+    return sim_pitch, sim_yaw, sim_roll
+
+
 def euler_to_quat(
     roll_deg: float,
     pitch_deg: float,

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -185,13 +185,12 @@ def remap_input_rpy(
 ) -> Tuple[float, float, float]:
     """Remap UI/TCP/MAV roll/pitch/yaw inputs into simulator order."""
 
-    # 각 채널(UI, TCP/IP, MAVLink)에서 전달되는 오일러각은 레이블과 실제 축이
-    # 순환(rotated) 관계를 가진다. 입력 ``roll`` 값은 시뮬레이터의 Pitch, 입력
-    # ``pitch`` 값은 시뮬레이터의 Yaw, 입력 ``yaw`` 값은 시뮬레이터의 Roll에
-    # 대응하므로 이를 (Pitch, Yaw, Roll) 순서로 재배열한다.
-    sim_pitch = float(roll_deg)
-    sim_yaw = float(pitch_deg)
-    sim_roll = float(yaw_deg)
+    # UI/TCP/MAVLink 스택은 전통적으로 Roll, Pitch, Yaw 순서로 값을 노출하지만
+    # 언리얼 엔진 시뮬레이터는 (Pitch, Yaw, Roll) 순서의 ``FRotator`` 값을
+    # 기대한다. 후속 코드가 축을 혼동하지 않도록 시뮬레이터 순서로 재배열한다.
+    sim_pitch = float(pitch_deg)
+    sim_yaw = float(yaw_deg)
+    sim_roll = float(roll_deg)
     return sim_pitch, sim_yaw, sim_roll
 
 


### PR DESCRIPTION
## Summary
- add a shared helper that remaps roll/pitch/yaw inputs into simulator pitch/yaw/roll order
- use the remapping when applying UI presets and when parsing TCP SetTarget commands
- export the helper through the utils package so callers can share the same logic

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_690052228ec483258edbc46d302501ec