### PR TITLE
Add focal length based zoom control and update UI display

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Unreal 기반 MORAI Sim Air(MRO)와 외부 소프트웨어 사이에서 이미�
 
 - **Image Stream Module (ImageStreamBridge)**
   - UDP JPEG 수신 → 실시간 프리뷰 및 저장
-  - TCP `MroCameraControl`: `Req_Capture`(최신 프레임을 `SaveFile/000.jpg` 순환 저장), `Set_Count`, `Get_ImgNum`, `Req_SendImg`, `Set_Zoomratio`/`Get_Zoomratio`(응답 `Ack_Zoomratio`) 지원
+  - TCP `MroCameraControl`: `Req_Capture`(최신 프레임을 `SaveFile/000.jpg` 순환 저장), `Set_Count`, `Get_ImgNum`, `Req_SendImg`, `Set_ZoomLensDist`/`Get_ZoomLensDist`(응답 `Ack_ZoomLensDist`) 지원
 
   - `./SaveFile/000.jpg`(실시간 캡처) 또는 `./PreDefinedImageSet/000.jpg`(사전 이미지) 중 UI에서 선택 가능
   - GUI 프리뷰 스냅샷 저장: `./SaveFile/preview_<timestamp>.jpg`
@@ -141,13 +141,13 @@ pyinstaller --noconfirm --clean --name MroUnifiedBridge \
 | `0x03` | Set_Count | `<uint32 count_num>` | 다음 저장될 이미지 번호를 설정(000~999 순환). |
 | `0x04` | Get_ImgNum | `<uint8 get_flag=1>` | 마지막으로 저장된 이미지 번호 질의. `Img_Num_Response`(0x11) 반환. |
 | `0x05` | Req_SendImg | `<uint32 img_num>` | 지정 번호 이미지를 TCP 전송. `File_ImgTransfer`(0x12) 응답. |
-| `0x06` | Set_Zoomratio | `<float zoom_ratio>` | 디지털 줌 배율 설정. 적용된 배율은 `Ack_Zoomratio`(0x13)로 회신. |
-| `0x07` | Get_Zoomratio | `<uint8 get_flag=1>` | 현재 줌 배율 질의. `Ack_Zoomratio` 응답. |
+| `0x06` | Set_ZoomLensDist | `<float zoom_lens_mm>` | Focal Length(mm) 값을 전달(20/24/28/35/50/75). 가장 가까운 유효값으로 반올림하여 적용하며, 결과는 `Ack_ZoomLensDist`(0x13)로 회신. |
+| `0x07` | Get_ZoomLensDist | `<uint8 get_flag=1>` | 현재 적용된 Focal Length(mm) 질의. `Ack_ZoomLensDist` 응답. |
 | `0x11` | Img_Num_Response | `<uint32 ack_uuid><uint32 img_num>` | 마지막 저장 번호 응답(기존 동작 유지). |
 | `0x12` | File_ImgTransfer | `<uint32 ack_uuid><uint32 img_num><uint32 data_size><byte[] data>` | JPEG 바이너리 응답(줌 1.0 초과 시 중앙 크롭 후 리사이즈). |
-| `0x13` | Ack_Zoomratio | `<float zoom_ratio>` | Set/Get 요청에 대한 현재 줌 배율 회신. |
+| `0x13` | Ack_ZoomLensDist | `<float zoom_lens_mm>` | Set/Get 요청에 대한 현재 Focal Length(mm) 회신. |
 
-> `zoom_ratio` 는 디지털 확대 배율(1.0 = 원본)이며, Pillow 가 사용 가능하면 JPEG 중앙부를 crop 후 원 해상도로 리사이즈하여 적용합니다.
+> `zoom_lens_mm` 은 20 mm(배율 x1.0)를 기준으로 75 mm(x3.75)까지 선형 매핑되며, Pillow 가 사용 가능하면 JPEG 중앙부를 crop 후 원 해상도로 리사이즈하여 적용합니다.
 
 ### TCP `GimbalControl` Command Set
 - Framing: `<uint32 payload_len>` prefix + payload (`payload_len` bytes)

--- a/core/gimbal_control.py
+++ b/core/gimbal_control.py
@@ -17,6 +17,7 @@ except ImportError:
     from serial.serialutil import SerialException
 
 from utils.helpers import euler_to_quat, wrap_angle_deg
+from utils.zoom import zoom_scale_to_lens_mm
 from network.bridge_tcp import parse_bridge_tcp_command
 from network.gimbal_icd import (
     MC_HB_TYPE,
@@ -738,6 +739,7 @@ class GimbalControl:
                 "mav_sysid": self.mav_sys_id,
                 "mav_compid": self.mav_comp_id,
                 "zoom_scale": self.zoom_scale,
+                "zoom_lens_mm": zoom_scale_to_lens_mm(self.zoom_scale, clamp=False),
                 "tcp_bind": f"{self.rx_ip}:{self.rx_port}",
             }
 
@@ -892,7 +894,8 @@ class GimbalControl:
                 self.log("[GIMBAL] TCP SET_ZOOM invalid payload")
                 return
             self._set_zoom_scale(zoom.zoom_scale)
-            self.log(f"[GIMBAL] TCP zoom scale -> {self.zoom_scale:.2f}")
+            lens_mm = zoom_scale_to_lens_mm(self.zoom_scale, clamp=False)
+            self.log(f"[GIMBAL] TCP zoom -> x{self.zoom_scale:.2f} ({lens_mm:.1f}mm)")
             self._send_status_message(conn)
         elif command.cmd_id == TCP_CMD_GET_STATUS:
             self._send_status_message(conn)

--- a/network/image_stream_icd.py
+++ b/network/image_stream_icd.py
@@ -29,12 +29,12 @@ CMD_SET_GIMBAL = 0x02  # Reserved
 CMD_SET_COUNT = 0x03
 CMD_GET_IMG_NUM = 0x04
 CMD_REQ_SEND_IMG = 0x05
-CMD_SET_ZOOM_RATIO = 0x06
-CMD_GET_ZOOM_RATIO = 0x07
+CMD_SET_ZOOM_LENS_DIST = 0x06
+CMD_GET_ZOOM_LENS_DIST = 0x07
 
 CMD_IMG_NUM_RESPONSE = 0x11
 CMD_FILE_IMG_TRANSFER = 0x12
-CMD_ACK_ZOOM_RATIO = 0x13
+CMD_ACK_ZOOM_LENS_DIST = 0x13
 
 
 COMMAND_NAMES: Dict[int, str] = {
@@ -43,11 +43,11 @@ COMMAND_NAMES: Dict[int, str] = {
     CMD_SET_COUNT: "Set_Count",
     CMD_GET_IMG_NUM: "Get_Img_Num",
     CMD_REQ_SEND_IMG: "Req_Send_Img",
-    CMD_SET_ZOOM_RATIO: "Set_Zoomratio",
-    CMD_GET_ZOOM_RATIO: "Get_Zoomratio",
+    CMD_SET_ZOOM_LENS_DIST: "Set_ZoomLensDist",
+    CMD_GET_ZOOM_LENS_DIST: "Get_ZoomLensDist",
     CMD_IMG_NUM_RESPONSE: "Img_Num_Response",
     CMD_FILE_IMG_TRANSFER: "File_Img_Transfer",
-    CMD_ACK_ZOOM_RATIO: "Ack_Zoomratio",
+    CMD_ACK_ZOOM_LENS_DIST: "Ack_ZoomLensDist",
 }
 
 
@@ -84,11 +84,11 @@ __all__ = [
     "CMD_SET_COUNT",
     "CMD_GET_IMG_NUM",
     "CMD_REQ_SEND_IMG",
-    "CMD_SET_ZOOM_RATIO",
-    "CMD_GET_ZOOM_RATIO",
+    "CMD_SET_ZOOM_LENS_DIST",
+    "CMD_GET_ZOOM_LENS_DIST",
     "CMD_IMG_NUM_RESPONSE",
     "CMD_FILE_IMG_TRANSFER",
-    "CMD_ACK_ZOOM_RATIO",
+    "CMD_ACK_ZOOM_LENS_DIST",
     "COMMAND_NAMES",
     "parse_udp_header",
     "pack_tcp_response",

--- a/utils/zoom.py
+++ b/utils/zoom.py
@@ -1,0 +1,58 @@
+"""Zoom/Focal-length helper utilities."""
+from __future__ import annotations
+
+from math import isnan
+from typing import Tuple
+
+__all__ = [
+    "ALLOWED_ZOOM_LENS_MM",
+    "BASE_ZOOM_LENS_MM",
+    "MAX_ZOOM_SCALE",
+    "normalize_zoom_lens_dist",
+    "zoom_scale_to_lens_mm",
+    "lens_mm_to_zoom_scale",
+]
+
+ALLOWED_ZOOM_LENS_MM: Tuple[float, ...] = (20.0, 24.0, 28.0, 35.0, 50.0, 75.0)
+BASE_ZOOM_LENS_MM: float = ALLOWED_ZOOM_LENS_MM[0]
+MAX_ZOOM_SCALE: float = ALLOWED_ZOOM_LENS_MM[-1] / BASE_ZOOM_LENS_MM
+
+
+def _sanitize_value(value: float) -> float:
+    try:
+        numeric = float(value)
+    except Exception:
+        return BASE_ZOOM_LENS_MM
+    if isnan(numeric):
+        return BASE_ZOOM_LENS_MM
+    return numeric
+
+
+def normalize_zoom_lens_dist(lens_mm: float) -> tuple[float, float]:
+    """Clamp *lens_mm* to the supported list and return ``(mm, scale)``.
+
+    The TCP protocol only accepts the discrete focal lengths described in
+    :data:`ALLOWED_ZOOM_LENS_MM`. Values outside the range are clamped and then
+    rounded to the nearest supported entry (round-half-up semantics are
+    achieved by picking the smallest candidate when the distance matches).
+    """
+
+    value = _sanitize_value(lens_mm)
+    lower, upper = ALLOWED_ZOOM_LENS_MM[0], ALLOWED_ZOOM_LENS_MM[-1]
+    value = max(lower, min(upper, value))
+    mm = min(ALLOWED_ZOOM_LENS_MM, key=lambda candidate: (abs(candidate - value), candidate))
+    scale = mm / BASE_ZOOM_LENS_MM
+    return mm, scale
+
+
+def lens_mm_to_zoom_scale(lens_mm: float) -> float:
+    value = _sanitize_value(lens_mm)
+    return max(1.0, min(MAX_ZOOM_SCALE, value / BASE_ZOOM_LENS_MM))
+
+
+def zoom_scale_to_lens_mm(scale: float, *, clamp: bool = False) -> float:
+    value = _sanitize_value(scale) * BASE_ZOOM_LENS_MM
+    if not clamp:
+        return value
+    lower, upper = ALLOWED_ZOOM_LENS_MM[0], ALLOWED_ZOOM_LENS_MM[-1]
+    return max(lower, min(upper, value))


### PR DESCRIPTION
## Summary
- switch the MroCameraControl zoom commands to work with discrete focal length (ZoomLensDist) values and reply with rounded mm values
- add shared zoom conversion helpers and expose focal length data through gimbal/image bridge status, logging, and documentation
- update the main window zoom label and gimbal status badge to show both zoom ratio and focal length

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_690063e5e32c83258b88beabb6f5eb6f