### PR TITLE
Ensure gimbal controller tracks shared zoom state

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,6 +84,7 @@ class ServiceController(QtCore.QObject):
         )
 
         self.zoom_state.subscribe(self.bridge.set_zoom_scale)
+        self.zoom_state.subscribe(self.gimbal.set_zoom_scale)
         self.bridge.attach_gimbal_controller(self.gimbal)
 
         try:


### PR DESCRIPTION
## Summary
- subscribe the gimbal controller to the shared zoom observable so zoom updates propagate

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_6901948436e08325b85dea93824ab799