### PR TITLE
Fix MAVLink control mode toggling from main UI

### DIFF
--- a/core/gimbal_control.py
+++ b/core/gimbal_control.py
@@ -371,6 +371,14 @@ class GimbalControl:
 
     # -------- public controls --------
 
+    def update_control_method(self, method: str) -> None:
+        """Switch between TCP and MAVLink control modes at runtime."""
+
+        requested = self._normalize_control_method(method)
+        if requested == self.control_method:
+            return
+        self.update_settings({"control_method": requested})
+
     def _apply_control_method_runtime(self, restart: bool = False) -> None:
         if self.control_method == "mavlink":
             if restart:


### PR DESCRIPTION
## Summary
- add a dedicated control-method switch helper inside `GimbalControl`
- wire the main window radio buttons to the helper and show errors when switching fails

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_690454952278832597fecd78a80ac903