### PR TITLE
Remap output quaternions for bridge endpoints

### DIFF
--- a/core/gimbal_control.py
+++ b/core/gimbal_control.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     from serial.serialutil import SerialException
 
-from utils.helpers import euler_to_quat, wrap_angle_deg
+from utils.helpers import euler_to_quat, remap_quat_output, wrap_angle_deg
 from utils.zoom import zoom_scale_to_lens_mm
 from network.bridge_tcp import parse_bridge_tcp_command
 from network.gimbal_icd import (
@@ -1149,7 +1149,7 @@ class GimbalControl:
                     orientation = self._orientation_pipeline.build_from_sim(
                         sim_pitch, sim_yaw, sim_roll, channel="mav"
                     )
-                    qx, qy, qz, qw = orientation.quat_xyzw
+                    qx, qy, qz, qw = remap_quat_output(orientation.quat_xyzw)
                     sim_pitch_rate, sim_yaw_rate, sim_roll_rate = self._bridge_to_sim_rpy(wx_b, wy_b, wz_b)
                     time_boot_ms = int((now - t0) * 1000.0)
                     mav.mav.gimbal_device_attitude_status_send(

--- a/network/gimbal_messages.py
+++ b/network/gimbal_messages.py
@@ -14,7 +14,7 @@ from .gimbal_icd import (
     TCP_CMD_SET_ZOOM,
     TCP_CMD_STATUS,
 )
-from utils.helpers import remap_input_rpy
+from utils.helpers import remap_input_rpy, remap_quat_output
 
 _GIMBAL_CTRL_HEADER_FMT = "<BiIB"
 _GIMBAL_CTRL_PAYLOAD_FMT = "<BB3d4f"
@@ -64,10 +64,13 @@ def build_gimbal_ctrl_packet(
 ) -> bytes:
     """Pack the UDP control packet consumed by the ImageGenerator.
 
-    The quaternion must be supplied in ``(x, y, z, w)`` order to match the
-    :func:`utils.helpers.euler_to_quat` helper used by the bridge.
+    The quaternion should be supplied in canonical ``(x, y, z, w)`` order as
+    produced by :func:`utils.helpers.euler_to_quat`.  The vector part is then
+    remapped so that the output tuple exposes (Yaw→Roll, Roll→Pitch, Pitch→Yaw)
+    to satisfy the simulator expectation without disturbing upstream pipelines.
     """
 
+    qx, qy, qz, qw = remap_quat_output(quat_xyzw)
     payload = struct.pack(
         _GIMBAL_CTRL_PAYLOAD_FMT,
         sensor_type & 0xFF,
@@ -75,10 +78,10 @@ def build_gimbal_ctrl_packet(
         float(position_xyz[0]),
         float(position_xyz[1]),
         float(position_xyz[2]),
-        float(quat_xyzw[0]),
-        float(quat_xyzw[1]),
-        float(quat_xyzw[2]),
-        float(quat_xyzw[3]),
+        float(qx),
+        float(qy),
+        float(qz),
+        float(qw),
     )
     header = struct.pack(_GIMBAL_CTRL_HEADER_FMT, 1, TYPE_GIMBAL_CTRL, len(payload), 0)
     return header + payload

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -282,6 +282,26 @@ def euler_to_quat(
     )
 
 
+def remap_quat_output(
+    quat_xyzw: Tuple[float, float, float, float]
+) -> Tuple[float, float, float, float]:
+    """Reorder the quaternion vector part for final bridge outputs.
+
+    최종 출력 경로(UDP, TCP, MAVLink)에서는 현재 쿼터니언의 Roll(X) 값이
+    Pitch(Y) 위치로, Pitch(Y) 값이 Yaw(Z) 위치로, Yaw(Z) 값이 Roll(X) 위치로
+    이동하도록 재배열한다.  스칼라부 ``w`` 는 그대로 유지하여 짐벌락 방지용
+    최단호 선택 로직에 영향을 주지 않는다.
+    """
+
+    x, y, z, w = (
+        float(quat_xyzw[0]),
+        float(quat_xyzw[1]),
+        float(quat_xyzw[2]),
+        float(quat_xyzw[3]),
+    )
+    return (z, x, y, w)
+
+
 def clamp(v: float, vmin: Optional[float], vmax: Optional[float]) -> float:
     """
     v를 [vmin, vmax] 영역으로 클램프.


### PR DESCRIPTION
## Summary
- add a shared helper that remaps quaternion vector components for bridge outputs
- apply the new roll→pitch→yaw rotation when packing UDP control packets
- send MAVLink attitude quaternions using the updated component order

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_69080ef4d0908325ab4a07aa96d2e332