### PR TITLE
Stabilize remapped quaternion outputs

### DIFF
--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -282,6 +282,26 @@ def euler_to_quat(
     )
 
 
+def remap_quat_output(
+    quat_xyzw: Tuple[float, float, float, float]
+) -> Tuple[float, float, float, float]:
+    """Reorder the quaternion vector part for final bridge outputs.
+
+    최종 출력 경로(UDP, TCP, MAVLink)에서는 기존 Roll(X) → Pitch(Y),
+    Pitch(Y) → Yaw(Z), Yaw(Z) → Roll(X) 순으로 벡터부를 재배열한다. 스칼라부
+    ``w`` 는 그대로 유지하여 짐벌락 방지용 최단호 선택 로직에 영향을 주지
+    않는다.
+    """
+
+    x, y, z, w = (
+        float(quat_xyzw[0]),
+        float(quat_xyzw[1]),
+        float(quat_xyzw[2]),
+        float(quat_xyzw[3]),
+    )
+    return (y, z, x, w)
+
+
 def clamp(v: float, vmin: Optional[float], vmax: Optional[float]) -> float:
     """
     v를 [vmin, vmax] 영역으로 클램프.


### PR DESCRIPTION
## Summary
- remap the quaternion vector portion so roll feeds pitch, pitch feeds yaw, and yaw feeds roll at the bridge outputs
- cache the remapped quaternions per channel so shortest-arc enforcement runs on the final ordering before packets are emitted
- refresh the UDP packet helper documentation to describe the new component mapping

## Testing
- python -m compileall core/gimbal_control.py network/gimbal_messages.py utils/helpers.py

------
https://chatgpt.com/codex/tasks/task_e_69080ef4d0908325ab4a07aa96d2e332