### PR TITLE
Fix gimbal quaternion output ordering

### DIFF
--- a/core/gimbal_control.py
+++ b/core/gimbal_control.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     from serial.serialutil import SerialException
 
-from utils.helpers import euler_to_quat, remap_quat_output, wrap_angle_deg
+from utils.helpers import euler_to_quat, wrap_angle_deg
 from utils.zoom import zoom_scale_to_lens_mm
 from network.bridge_tcp import parse_bridge_tcp_command
 from network.gimbal_icd import (
@@ -91,7 +91,6 @@ class _SimOrientationPipeline:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._last_quat: Dict[str, Tuple[float, float, float, float]] = {}
-        self._last_output_quat: Dict[str, Tuple[float, float, float, float]] = {}
 
     def reset(self, channel: Optional[str] = None) -> None:
         """Clear cached quaternions used for shortest-arc enforcement."""
@@ -99,10 +98,8 @@ class _SimOrientationPipeline:
         with self._lock:
             if channel is None:
                 self._last_quat.clear()
-                self._last_output_quat.clear()
             else:
                 self._last_quat.pop(channel, None)
-                self._last_output_quat.pop(channel, None)
 
     def build_from_sim(
         self,
@@ -123,23 +120,18 @@ class _SimOrientationPipeline:
         quat = euler_to_quat(bridge_roll, bridge_pitch, bridge_yaw)
 
         if channel:
-            output_quat = remap_quat_output(quat)
             with self._lock:
-                prev_output = self._last_output_quat.get(channel)
-                if prev_output is not None:
-                    dot = sum(a * b for a, b in zip(output_quat, prev_output))
+                prev_quat = self._last_quat.get(channel)
+                if prev_quat is not None:
+                    dot = sum(a * b for a, b in zip(quat, prev_quat))
                     if dot < 0.0:
                         quat = tuple(-a for a in quat)
-                        output_quat = tuple(-a for a in output_quat)
                 else:
                     if quat[3] < 0.0:
                         quat = tuple(-a for a in quat)
-                        output_quat = tuple(-a for a in output_quat)
                     else:
                         quat = tuple(quat)
-                        output_quat = tuple(output_quat)
                 self._last_quat[channel] = tuple(quat)
-                self._last_output_quat[channel] = tuple(output_quat)
         else:
             if quat[3] < 0.0:
                 quat = tuple(-a for a in quat)
@@ -1167,7 +1159,7 @@ class GimbalControl:
                     orientation = self._orientation_pipeline.build_from_sim(
                         sim_pitch, sim_yaw, sim_roll, channel="mav"
                     )
-                    qx, qy, qz, qw = remap_quat_output(orientation.quat_xyzw)
+                    qx, qy, qz, qw = orientation.quat_xyzw
                     sim_pitch_rate, sim_yaw_rate, sim_roll_rate = self._bridge_to_sim_rpy(wx_b, wy_b, wz_b)
                     time_boot_ms = int((now - t0) * 1000.0)
                     mav.mav.gimbal_device_attitude_status_send(
@@ -1175,7 +1167,7 @@ class GimbalControl:
                         self.mav_comp_id,
                         time_boot_ms,
                         GIMBAL_STATUS_FLAGS,
-                        [qx, qy, qz, qw],
+                        [qw, qx, qy, qz],
                         sim_roll_rate,
                         sim_pitch_rate,
                         sim_yaw_rate,

--- a/network/gimbal_messages.py
+++ b/network/gimbal_messages.py
@@ -14,7 +14,7 @@ from .gimbal_icd import (
     TCP_CMD_SET_ZOOM,
     TCP_CMD_STATUS,
 )
-from utils.helpers import remap_input_rpy, remap_quat_output
+from utils.helpers import remap_input_rpy
 
 _GIMBAL_CTRL_HEADER_FMT = "<BiIB"
 _GIMBAL_CTRL_PAYLOAD_FMT = "<BB3d4f"
@@ -65,12 +65,12 @@ def build_gimbal_ctrl_packet(
     """Pack the UDP control packet consumed by the ImageGenerator.
 
     The quaternion should be supplied in canonical ``(x, y, z, w)`` order as
-    produced by :func:`utils.helpers.euler_to_quat`.  The vector part is then
-    remapped so that the output tuple exposes (Roll→Pitch, Pitch→Yaw, Yaw→Roll)
-    to satisfy the simulator expectation without disturbing upstream pipelines.
+    produced by :func:`utils.helpers.euler_to_quat`.  The values are forwarded
+    without axis remapping so downstream consumers interpret them using the
+    standard roll/pitch/yaw convention.
     """
 
-    qx, qy, qz, qw = remap_quat_output(quat_xyzw)
+    qx, qy, qz, qw = quat_xyzw
     payload = struct.pack(
         _GIMBAL_CTRL_PAYLOAD_FMT,
         sensor_type & 0xFF,

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -282,26 +282,6 @@ def euler_to_quat(
     )
 
 
-def remap_quat_output(
-    quat_xyzw: Tuple[float, float, float, float]
-) -> Tuple[float, float, float, float]:
-    """Reorder the quaternion vector part for final bridge outputs.
-
-    최종 출력 경로(UDP, TCP, MAVLink)에서는 기존 Roll(X) → Pitch(Y),
-    Pitch(Y) → Yaw(Z), Yaw(Z) → Roll(X) 순으로 벡터부를 재배열한다. 스칼라부
-    ``w`` 는 그대로 유지하여 짐벌락 방지용 최단호 선택 로직에 영향을 주지
-    않는다.
-    """
-
-    x, y, z, w = (
-        float(quat_xyzw[0]),
-        float(quat_xyzw[1]),
-        float(quat_xyzw[2]),
-        float(quat_xyzw[3]),
-    )
-    return (y, z, x, w)
-
-
 def clamp(v: float, vmin: Optional[float], vmax: Optional[float]) -> float:
     """
     v를 [vmin, vmax] 영역으로 클램프.


### PR DESCRIPTION
## Summary
- stop remapping quaternion components when building gimbal control packets
- update the shortest-arc cache and MAVLink publisher to keep quaternions in canonical order
- drop the unused quaternion remapping helper

## Testing
- python -m compileall core/gimbal_control.py network/gimbal_messages.py utils/helpers.py

------
https://chatgpt.com/codex/tasks/task_e_690868a777ac8325907b79102bccf679