### PR TITLE
Refactor gimbal control to quaternion-based control loop

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -34,6 +34,13 @@ try:
         euler_to_quat,
         wrap_angle_deg,
         remap_input_rpy,
+        quat_conjugate_xyzw,
+        quat_from_axis_angle,
+        quat_from_wxyz,
+        quat_multiply_xyzw,
+        quat_normalize_xyzw,
+        quat_to_axis_angle,
+        quat_to_euler,
         clamp,
         rate_limit,
     )
@@ -44,7 +51,21 @@ except Exception:  # pragma: no cover
         euler_to_quat
     ) = (
         wrap_angle_deg
-    ) = remap_input_rpy = clamp = rate_limit = None  # type: ignore
+    ) = remap_input_rpy = (
+        quat_conjugate_xyzw
+    ) = (
+        quat_from_axis_angle
+    ) = (
+        quat_from_wxyz
+    ) = (
+        quat_multiply_xyzw
+    ) = (
+        quat_normalize_xyzw
+    ) = (
+        quat_to_axis_angle
+    ) = (
+        quat_to_euler
+    ) = clamp = rate_limit = None  # type: ignore
 
 
 __all__ = [
@@ -61,6 +82,13 @@ __all__ = [
     "euler_to_quat",
     "wrap_angle_deg",
     "remap_input_rpy",
+    "quat_conjugate_xyzw",
+    "quat_from_axis_angle",
+    "quat_from_wxyz",
+    "quat_multiply_xyzw",
+    "quat_normalize_xyzw",
+    "quat_to_axis_angle",
+    "quat_to_euler",
     "clamp",
     "rate_limit",
 ]


### PR DESCRIPTION
## Summary
- rework the gimbal control loop to operate on quaternion state snapshots and derive angular velocity vectors
- update UDP/TCP/MAVLink pose handling to convert between quaternion, bridge RPY, and simulator conventions without gimbal lock
- add shared quaternion math helpers for normalization, multiplication, axis-angle conversion, and Euler extraction

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_69086f9873cc8325a68d7bd001ed723a