### PR TITLE
Ensure image stream disconnect drops TCP listener

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -663,7 +663,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if not callable(disconnect):
                 return RuntimeError("disconnect not supported"), False
             try:
-                result = bool(disconnect())
+                result = bool(disconnect(restart_listener=True))
             except Exception as exc:  # pragma: no cover - runtime guard
                 return exc, False
             return None, result


### PR DESCRIPTION
## Summary
- recycle the image stream TCP listener when the UI disconnect button is used so the client connection is forcibly dropped
- guard TCP socket operations with a lock and allow the accept loop to survive listener restarts
- update the UI to request the listener restart when invoking the disconnect helper

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_690c14a5b1ec832589001e1c4472e77a