### PR TITLE
Add UI control to enable or disable image stream TCP listener

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -117,6 +117,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._preview_target_size = QtCore.QSize(640, 480)
         self._disconnect_in_progress = False
         self._background_watchers: list[QtCore.QFutureWatcher] = []
+        self._bridge_cfg = self.cfg.setdefault("bridge", {})
+        self._initial_tcp_enabled = bool(self._bridge_cfg.get("enable_tcp", True))
+        self.chk_tcp_enabled: Optional[QtWidgets.QCheckBox] = None
 
         gimbal_cfg = self.cfg.setdefault("gimbal", {})
         initial_method = str(gimbal_cfg.get("control_method", "tcp")).lower()
@@ -202,6 +205,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_bridge = QtWidgets.QPushButton("Image Stream Settings")
         self.btn_bridge.clicked.connect(self.open_bridge_window)
         bridge_buttons.addWidget(self.btn_bridge)
+        self.chk_tcp_enabled = QtWidgets.QCheckBox("Enable TCP/IP Connection")
+        self.chk_tcp_enabled.setChecked(self._initial_tcp_enabled)
+        self.chk_tcp_enabled.toggled.connect(self._on_tcp_enable_toggled)
+        bridge_buttons.addWidget(self.chk_tcp_enabled)
         bridge_buttons.addStretch()
         bridge_layout.addLayout(bridge_buttons)
 
@@ -468,11 +475,19 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             st = {}
         client_connected = bool(st.get("tcp_client_connected"))
+        tcp_enabled = bool(st.get("tcp_enabled", True))
+        if self.chk_tcp_enabled is not None and self.chk_tcp_enabled.isChecked() != tcp_enabled:
+            self.chk_tcp_enabled.blockSignals(True)
+            self.chk_tcp_enabled.setChecked(tcp_enabled)
+            self.chk_tcp_enabled.blockSignals(False)
         if not self._disconnect_in_progress:
             self.btn_server.setEnabled(client_connected)
 
         mode = st.get("image_source_mode", "Realtime")
-        tcp_on = "ON" if st.get("tcp_listening") else "OFF"
+        if not tcp_enabled:
+            tcp_on = "DISABLED"
+        else:
+            tcp_on = "ON" if st.get("tcp_listening") else "OFF"
         udp_on = "ON" if st.get("udp_listening") else "OFF"
         client_on = "ON" if client_connected else "OFF"
         mode_label = str(mode)
@@ -652,6 +667,40 @@ class MainWindow(QtWidgets.QMainWindow):
     # ------------------------------------------------------------------
     # Button handlers
     # ------------------------------------------------------------------
+    def _on_tcp_enable_toggled(self, checked: bool) -> None:
+        desired = bool(checked)
+        setter = getattr(self.bridge, "set_tcp_enabled", None)
+        if not callable(setter):
+            self.log.error("[UI] Bridge does not support TCP enable toggle")
+            QtWidgets.QMessageBox.critical(self, "Error", "TCP/IP 연결 토글을 지원하지 않습니다.")
+            if self.chk_tcp_enabled is not None:
+                self.chk_tcp_enabled.blockSignals(True)
+                self.chk_tcp_enabled.setChecked(not desired)
+                self.chk_tcp_enabled.blockSignals(False)
+            return
+
+        try:
+            result = bool(setter(desired))
+        except Exception as exc:  # pragma: no cover - runtime guard
+            self.log.error("[UI] Failed to toggle TCP listener: %s", exc)
+            QtWidgets.QMessageBox.critical(self, "Error", f"TCP/IP 설정 변경 실패:\n{exc}")
+            if self.chk_tcp_enabled is not None:
+                self.chk_tcp_enabled.blockSignals(True)
+                self.chk_tcp_enabled.setChecked(not desired)
+                self.chk_tcp_enabled.blockSignals(False)
+            return
+
+        if result != desired:
+            self.log.warning("[UI] TCP listener state mismatch: requested=%s got=%s", desired, result)
+            if self.chk_tcp_enabled is not None:
+                self.chk_tcp_enabled.blockSignals(True)
+                self.chk_tcp_enabled.setChecked(result)
+                self.chk_tcp_enabled.blockSignals(False)
+            desired = result
+
+        self.cfg.setdefault("bridge", {})["enable_tcp"] = desired
+        self._refresh_status_labels()
+
     def on_disconnect_stream(self) -> None:
         if self._disconnect_in_progress:
             return
@@ -663,7 +712,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if not callable(disconnect):
                 return RuntimeError("disconnect not supported"), False
             try:
-                result = bool(disconnect())
+                result = bool(disconnect(restart_listener=True))
             except Exception as exc:  # pragma: no cover - runtime guard
                 return exc, False
             return None, result

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -191,6 +191,15 @@ class AppConfig:
         ensure_dir(b["realtime_dir"])
         ensure_dir(b["predefined_dir"])
 
+        enable_tcp = b.get("enable_tcp")
+        if isinstance(enable_tcp, str):
+            enable_tcp = enable_tcp.strip().lower() not in {"false", "0", "no", "off"}
+        elif enable_tcp is None:
+            enable_tcp = True
+        else:
+            enable_tcp = bool(enable_tcp)
+        b["enable_tcp"] = enable_tcp
+
         b.setdefault("image_source_mode", "realtime")
         b["images"] = b["realtime_dir"]
         # GUI 미리보기 등


### PR DESCRIPTION
## Summary
- add a normalized TCP enable flag to the image stream bridge and expose a setter plus runtime status updates
- allow the main window to toggle TCP listening via a new "Enable TCP/IP Connection" checkbox and reflect the disabled state in the status label
- persist the TCP enable flag in settings with legacy-safe coercion

## Testing
- python -m compileall core/image_stream_bridge.py ui/main_window.py utils/settings.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690c14a5b1ec832589001e1c4472e77a)