### PR TITLE
Flip simulator yaw for LH coordinate system

### DIFF
--- a/unified_bridge/services/gimbal_control.py
+++ b/unified_bridge/services/gimbal_control.py
@@ -1202,10 +1202,12 @@ class GimbalControl:
                 )
                 
                 if should_send:
-                    # ✅ q_cur (리맵핑된 쿼터니언)을 q_to_send로 설정
-                    q_to_send = self.q_cur
-
-                    r_cur_mapped, p_cur_mapped, y_cur_mapped = self._q_to_rpy(q_to_send)
+                    # ✅ q_cur (리맵핑된 쿼터니언)을 시뮬레이터 전송용으로 변환
+                    r_cur_mapped, p_cur_mapped, y_cur_mapped = self._q_to_rpy(self.q_cur)
+                    # LH(시뮬레이터) ↔ RH(유저) 좌표계 차이로 인한 Yaw 방향 반전을 반영
+                    q_to_send = self._rpy_to_quat(
+                        r_cur_mapped, p_cur_mapped, -y_cur_mapped
+                    )
                     r_cur_orig, p_cur_orig, y_cur_orig = self._inverse_remap_rpy_for_status(
                         r_cur_mapped, p_cur_mapped, y_cur_mapped
                     )


### PR DESCRIPTION
## Summary
- invert yaw when preparing simulator-bound gimbal quaternions to account for LH vs RH coordinate systems
- preserve existing roll/pitch mapping while logging updated quaternion values

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ea14900a483259ea1fb35f34fbc93)