### PR TITLE
Limit simulator yaw inversion to TCP control input

### DIFF
--- a/unified_bridge/services/gimbal_control.py
+++ b/unified_bridge/services/gimbal_control.py
@@ -736,7 +736,11 @@ class GimbalControl:
                 r_cur_mapped, p_cur_mapped, y_cur_mapped
             )
 
-            left_handed_rpy = (r_cur_mapped, p_cur_mapped, y_cur_mapped)
+            # LH RPY는 시뮬레이터 송신용(quaternion) 기준으로 표시
+            yaw_mapped_for_sim = (
+                -y_cur_mapped if self.control_method == "tcp" else y_cur_mapped
+            )
+            left_handed_rpy = (r_cur_mapped, p_cur_mapped, yaw_mapped_for_sim)
             right_handed_rpy = (r_orig, p_orig, y_orig)
 
             return {
@@ -1202,10 +1206,15 @@ class GimbalControl:
                 )
                 
                 if should_send:
-                    # ✅ q_cur (리맵핑된 쿼터니언)을 q_to_send로 설정
-                    q_to_send = self.q_cur
-
-                    r_cur_mapped, p_cur_mapped, y_cur_mapped = self._q_to_rpy(q_to_send)
+                    # ✅ q_cur (리맵핑된 쿼터니언)을 시뮬레이터 전송용으로 변환
+                    r_cur_mapped, p_cur_mapped, y_cur_mapped = self._q_to_rpy(self.q_cur)
+                    # TCP 입력(RPY)만 시뮬레이터 LH 좌표계에 맞춰 Yaw 반전을 적용
+                    yaw_for_sim = (
+                        -y_cur_mapped if self.control_method == "tcp" else y_cur_mapped
+                    )
+                    q_to_send = self._rpy_to_quat(
+                        r_cur_mapped, p_cur_mapped, yaw_for_sim
+                    )
                     r_cur_orig, p_cur_orig, y_cur_orig = self._inverse_remap_rpy_for_status(
                         r_cur_mapped, p_cur_mapped, y_cur_mapped
                     )


### PR DESCRIPTION
## Summary
- apply yaw inversion for LH simulator orientation only when using TCP RPY control, leaving MAVLink quaternion inputs untouched
- align left-handed RPY status display with the per-control-method yaw handling sent to the simulator

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ea14900a483259ea1fb35f34fbc93)